### PR TITLE
Use build-machinery-go to build

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,44 +1,29 @@
 SHELL := /usr/bin/env bash
-default: help
+
+GO_TEST_PACKAGES :=./pkg/... ./cmd/...
+GO_BUILD_BINDIR := bin
+
+.PHONY: all
+all: build
 
 # bingo manages consistent tooling versions for things like kind, kustomize, etc.
 include .bingo/Variables.mk
+
+include $(addprefix ./vendor/github.com/openshift/build-machinery-go/make/, \
+    golang.mk \
+    targets/openshift/deps.mk \
+)
 
 # golangci-lint on *nix uses XDG_CACHE_HOME, falling back to HOME, as the default storage directory. Some CI setups
 # don't have XDG_CACHE_HOME set; in those cases, we set it here so lint functions correctly. This shouldn't
 # affect developers.
 export XDG_CACHE_HOME ?= /tmp/.local/cache
 
-##@ General
-
-# The help target prints out all targets with their descriptions organized
-# beneath their categories. The categories are represented by '##@' and the
-# target descriptions by '##'. The awk commands is responsible for reading the
-# entire set of makefiles included in this invocation, looking for lines of the
-# file as xyz: ## something, and then pretty-format the target and help. Then,
-# if there's a line with ##@ something, that gets pretty-printed as a category.
-# More info on the usage of ANSI control characters for terminal formatting:
-# https://en.wikipedia.org/wiki/ANSI_escape_code#SGR_parameters
-# More info on the awk command:
-# http://linuxcommand.org/lc3_adv_awk.php
-
-.PHONY: help
-help: ## Display this help.
-	@awk 'BEGIN {FS = ":.*##"; printf "Usage:\n  make \033[36m<target>\033[0m\n"} /^[a-zA-Z_0-9-]+:.*?##/ { printf "  \033[36m%-15s\033[0m %s\n", $$1, $$2 } /^##@/ { printf "\n\033[1m%s\033[0m\n", substr($$0, 5) } ' $(MAKEFILE_LIST)
-
-##@ Development
-
 clean: ## Remove binaries and test artifacts
 	rm -rf bin
-
-.PHONY: build
-build: ## Build binaries
-	mkdir -p bin && go build -o bin ./cmd/cluster-olm-operator
 
 .PHONY: lint
 lint: $(GOLANGCI_LINT) ## Run golangci linter.
 	$(GOLANGCI_LINT) run $(GOLANGCI_LINT_ARGS)
 
-include $(addprefix ./vendor/github.com/openshift/build-machinery-go/make/, \
-    targets/openshift/deps.mk \
-)
+

--- a/cmd/cluster-olm-operator/main.go
+++ b/cmd/cluster-olm-operator/main.go
@@ -17,12 +17,12 @@ import (
 	"github.com/spf13/pflag"
 	"k8s.io/apimachinery/pkg/util/runtime"
 	"k8s.io/apimachinery/pkg/util/sets"
-	"k8s.io/apimachinery/pkg/version"
 	"k8s.io/component-base/cli"
 	utilflag "k8s.io/component-base/cli/flag"
 
 	"github.com/openshift/cluster-olm-operator/assets"
 	"github.com/openshift/cluster-olm-operator/pkg/clients"
+	"github.com/openshift/cluster-olm-operator/pkg/version"
 )
 
 func main() {
@@ -46,8 +46,7 @@ func newRootCommand() *cobra.Command {
 func newOperatorCommand() *cobra.Command {
 	cmd := controllercmd.NewControllerCommandConfig(
 		"cluster-olm-operator",
-		// TODO: lookup the actual version
-		version.Info{Major: "0", Minor: "0", GitVersion: "0.0.1"},
+		version.Get(),
 		runOperator,
 	).NewCommandWithContext(context.Background())
 	cmd.Use = "start"

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -1,0 +1,41 @@
+package version
+
+import (
+	"fmt"
+	"runtime"
+
+	"k8s.io/apimachinery/pkg/version"
+)
+
+var (
+	// commitFromGit is a constant representing the source version that
+	// generated this build. It should be set during build via -ldflags.
+	commitFromGit string
+	// versionFromGit is a constant representing the version tag that
+	// generated this build. It should be set during build via -ldflags.
+	versionFromGit string
+	// major version
+	majorFromGit string
+	// minor version
+	minorFromGit string
+	// build date in ISO8601 format, output of $(date -u +'%Y-%m-%dT%H:%M:%SZ')
+	buildDate string
+	// state of git tree, either "clean" or "dirty"
+	gitTreeState string
+)
+
+// Get returns the overall codebase version. It's for detecting
+// what code a binary was built from.
+func Get() version.Info {
+	return version.Info{
+		Major:        majorFromGit,
+		Minor:        minorFromGit,
+		GitCommit:    commitFromGit,
+		GitVersion:   versionFromGit,
+		BuildDate:    buildDate,
+		GitTreeState: gitTreeState,
+		Compiler:     runtime.Compiler,
+		Platform:     fmt.Sprintf("%s/%s", runtime.GOOS, runtime.GOARCH),
+		GoVersion:    runtime.Version(),
+	}
+}


### PR DESCRIPTION
Use build-machinery-go to build so we get the version information from ART or git appropriately linked in.

Runs something like this:

```
/usr/local/opt/go/libexec/bin/go build -mod=vendor -trimpath -ldflags "-X github.com/openshift/cluster-olm-operator/pkg/version.versionFromGit="v0.0.0-unknown-a066ee2" -X github.com/openshift/cluster-olm-operator/pkg/version.commitFromGit="a066ee2" -X github.com/openshift/cluster-olm-operator/pkg/version.gitTreeState="clean" -X github.com/openshift/cluster-olm-operator/pkg/version.buildDate="2023-06-29T20:57:11Z" " -o 'bin/cluster-olm-operator' github.com/openshift/cluster-olm-operator/cmd/cluster-olm-operator
```

Fixes #12 