### PR TITLE
OPRUN-3291: Add roles for clusterextensions

### DIFF
--- a/manifests/0000_51_olm_02_operator_clusterrole.yaml
+++ b/manifests/0000_51_olm_02_operator_clusterrole.yaml
@@ -197,3 +197,14 @@ rules:
     - list
     - watch
     - delete
+  # For validating admission policies and bindings to work
+  # this service account must have "get" permission on resources
+  # mentioned in paramKind of the policy and have "list" permission
+  # on the resources mentioned in paramRef of the binding
+  - apiGroups:
+    - olm.operatorframework.io
+    resources:
+    - clusterextensions
+    verbs:
+    - get
+    - list


### PR DESCRIPTION
These are required for validatingadmissionpolicies and validatingadmissionpolicybindings to work.