### PR TITLE
AUTH-482: set required-scc for openshift workloads

### DIFF
--- a/manifests/0000_51_olm_06_deployment.yaml
+++ b/manifests/0000_51_olm_06_deployment.yaml
@@ -15,6 +15,7 @@ spec:
     metadata:
       annotations:
         target.workload.openshift.io/management: '{"effect": "PreferredDuringScheduling"}'
+        openshift.io/required-scc: restricted-v2
       labels:
         name: cluster-olm-operator
     spec:


### PR DESCRIPTION
#### Description of the change:

This PR explicitly sets the required SCC to be used to admit pods of the `cluster-olm-operator` deployment. The SCC chosen is the one that the pods are already getting admitted with, which means that this brings no change to the SCC used.

#### Motivation for the change:

In some cases, custom SCCs can have higher priority than default SCCs, which means that they will be chosen over the default ones. This can lead to unexpected results; in order to protect openshift workloads from this, we must explicitly pin the required SCC to all our workloads in order to make sure that the expected one will be used.
