### PR TITLE
OPRUN-3405: Stop building rukpak

### DIFF
--- a/cmd/cluster-olm-operator/main.go
+++ b/cmd/cluster-olm-operator/main.go
@@ -63,7 +63,7 @@ func runOperator(ctx context.Context, cc *controllercmd.ControllerContext) error
 		ControllerContext: cc,
 	}
 
-	controllers, relatedObjects, err := cb.BuildControllers("catalogd", "operator-controller", "rukpak")
+	controllers, relatedObjects, err := cb.BuildControllers("catalogd", "operator-controller")
 	if err != nil {
 		return err
 	}

--- a/manifests/0000_51_olm_06_deployment.yaml
+++ b/manifests/0000_51_olm_06_deployment.yaml
@@ -47,17 +47,6 @@ spec:
           volumeMounts:
           - mountPath: /operand-assets
             name: operand-assets
-        - name: copy-rukpak-manifests
-          image: quay.io/openshift/origin-olm-rukpak:latest
-          imagePullPolicy: IfNotPresent
-          command:
-          - /bin/sh
-          args:
-          - -c
-          - cp -a /openshift/manifests /operand-assets/rukpak
-          volumeMounts:
-          - mountPath: /operand-assets
-            name: operand-assets
       containers:
       - name: cluster-olm-operator
         image: quay.io/openshift/origin-cluster-olm-operator:latest

--- a/manifests/image-references
+++ b/manifests/image-references
@@ -14,10 +14,6 @@ spec:
     from:
       kind: DockerImage
       name: quay.io/openshift/origin-olm-operator-controller:latest
-  - name: olm-rukpak
-    from:
-      kind: DockerImage
-      name: quay.io/openshift/origin-olm-rukpak:latest
   - name: kube-rbac-proxy
     from:
       kind: DockerImage


### PR DESCRIPTION
As operator controller no longer depends on the rukpak APIs and controllers and we do not intend to support them in OLMv1 going forward. We need to ensure that they are not present/do not run.