### PR TITLE
[release-4.15] OCPBUGS-37395: manifests: set required-scc for openshift workloads

### DIFF
--- a/manifests/0000_51_olm_06_deployment.yaml
+++ b/manifests/0000_51_olm_06_deployment.yaml
@@ -15,6 +15,7 @@ spec:
     metadata:
       annotations:
         target.workload.openshift.io/management: '{"effect": "PreferredDuringScheduling"}'
+        openshift.io/required-scc: restricted-v2
       labels:
         name: cluster-olm-operator
     spec:


### PR DESCRIPTION
[OCPBUGS-37395](https://issues.redhat.com/browse/OCPBUGS-37395
)
Manual cherry-pick of [#54](https://github.com/openshift/cluster-olm-operator/pull/54)