### PR TITLE
OCPBUGS-37544: add version flag

### DIFF
--- a/cmd/cluster-olm-operator/main.go
+++ b/cmd/cluster-olm-operator/main.go
@@ -43,7 +43,10 @@ func newRootCommand() *cobra.Command {
 				fmt.Println(version.Get())
 				os.Exit(0)
 			}
-			cmd.Help()
+			if err := cmd.Help(); err != nil {
+				fmt.Println("Error displaying help:", err)
+				os.Exit(1)
+			}
 		},
 	}
 	cmd.PersistentFlags().BoolVarP(&versionFlag, "version", "V", false, "Print the version number and exit")
@@ -59,7 +62,6 @@ func newStartCommand() *cobra.Command {
 	).NewCommandWithContext(context.Background())
 	cmd.Use = "start"
 	cmd.Short = "Start the Cluster OLM Operator"
-
 	return cmd
 }
 

--- a/cmd/cluster-olm-operator/main.go
+++ b/cmd/cluster-olm-operator/main.go
@@ -3,6 +3,7 @@ package main
 import (
 	"context"
 	goflag "flag"
+	"fmt"
 	"os"
 
 	_ "github.com/openshift/api/operator/v1alpha1/zz_generated.crd-manifests"
@@ -32,10 +33,20 @@ func main() {
 }
 
 func newRootCommand() *cobra.Command {
+	var versionFlag bool
+
 	cmd := &cobra.Command{
 		Use:   "cluster-olm-operator",
 		Short: "OpenShift Cluster OLM Operator",
+		Run: func(cmd *cobra.Command, args []string) {
+			if versionFlag {
+				fmt.Println(version.Get())
+				os.Exit(0)
+			}
+			cmd.Help()
+		},
 	}
+	cmd.PersistentFlags().BoolVarP(&versionFlag, "version", "V", false, "Print the version number and exit")
 	cmd.AddCommand(newStartCommand())
 	return cmd
 }
@@ -48,6 +59,7 @@ func newStartCommand() *cobra.Command {
 	).NewCommandWithContext(context.Background())
 	cmd.Use = "start"
 	cmd.Short = "Start the Cluster OLM Operator"
+
 	return cmd
 }
 


### PR DESCRIPTION
As title, 
```console
jiazha-mac:cluster-olm-operator jiazha$ make build
fatal: No names found, cannot describe anything.
mkdir -p 'bin'
/Users/jiazha/golang/go1.21/bin/go build -mod=vendor -trimpath -ldflags "-X github.com/openshift/cluster-olm-operator/pkg/version.versionFromGit="v0.0.0-unknown-aa082ae" -X github.com/openshift/cluster-olm-operator/pkg/version.commitFromGit="aa082ae" -X github.com/openshift/cluster-olm-operator/pkg/version.gitTreeState="dirty" -X github.com/openshift/cluster-olm-operator/pkg/version.buildDate="2024-07-25T09:07:41Z" " -o 'bin/cluster-olm-operator' github.com/openshift/cluster-olm-operator/cmd/cluster-olm-operator

jiazha-mac:cluster-olm-operator jiazha$ ./bin/cluster-olm-operator -V
v0.0.0-unknown-aa082ae
jiazha-mac:cluster-olm-operator jiazha$ ./bin/cluster-olm-operator --version
v0.0.0-unknown-aa082ae
```