### PR TITLE
OCPBUGS-41799: Re-enable cluster-olm-operator

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,6 +10,6 @@ COPY manifests /manifests
 COPY vendor/github.com/openshift/api/operator/v1alpha1/zz_generated.crd-manifests/*_olms*.crd.yaml /manifests/
 USER 1001
 
-#LABEL io.openshift.release.operator=true \
-LABEL io.k8s.display-name="OpenShift Cluster Operator Lifecycle Manager (OLM) Operator" \
+LABEL io.openshift.release.operator=true \
+      io.k8s.display-name="OpenShift Cluster Operator Lifecycle Manager (OLM) Operator" \
       io.k8s.description="This cluster-olm-operator installs and maintains the Operator Lifecycle Manager (OLM) components of the OCP cluster."


### PR DESCRIPTION
Re-enables cluster-olm-operator's deployment in the payload (undoing #66)