### PR TITLE
Remove unncessary code for must-gather

### DIFF
--- a/cmd/cluster-olm-operator/main.go
+++ b/cmd/cluster-olm-operator/main.go
@@ -7,9 +7,6 @@ import (
 	"os"
 	"time"
 
-	configv1 "github.com/openshift/api/config/v1"
-	operatorv1alpha1 "github.com/openshift/api/operator/v1alpha1"
-
 	_ "github.com/openshift/api/operator/v1/zz_generated.crd-manifests"
 	"github.com/openshift/library-go/pkg/controller/controllercmd"
 	"github.com/openshift/library-go/pkg/controller/factory"
@@ -152,14 +149,6 @@ func runOperator(ctx context.Context, cc *controllercmd.ControllerContext) error
 	versionGetter := status.NewVersionGetter()
 	versionGetter.SetVersion("operator", status.VersionForOperatorFromEnv())
 
-	// Add OLM resource and openshift-cluster-olm-operator namespace to relatedObjects
-	// to ensure that must-gather picks them up.
-	// Note: These two resources are also hard-coded in the ClusterOperator manifest. This way,
-	// must-gather will pick them up in case of catastrophic failure before we cluster-olm-operator
-	// gets a chance to dynamically update the relatedObjects. Thus, making the pod logs accessible
-	// for troubleshooting in the must-gather.
-	relatedObjects = append(relatedObjects, newOLMObjectReference(), newNamespaceObjectReference())
-
 	clusterOperatorController := status.NewClusterOperatorStatusController(
 		"olm",
 		relatedObjects,
@@ -199,24 +188,4 @@ func runOperator(ctx context.Context, cc *controllercmd.ControllerContext) error
 
 	<-ctx.Done()
 	return nil
-}
-
-// newOLMObjectReference creates a configv1.ObjectReference for
-// the cluster scoped OLM resources
-func newOLMObjectReference() configv1.ObjectReference {
-	return configv1.ObjectReference{
-		Group:    operatorv1alpha1.GroupName,
-		Resource: "olms",
-		Name:     "cluster",
-	}
-}
-
-// newNamespaceObjectReferences creates a configv1.ObjectReference for
-// the OCP namespaces where this operator is installed: openshift-cluster-olm-operator
-func newNamespaceObjectReference() configv1.ObjectReference {
-	return configv1.ObjectReference{
-		Group:    "",
-		Resource: "namespaces",
-		Name:     "openshift-cluster-olm-operator",
-	}
 }


### PR DESCRIPTION
Looking at the code more closely, I don't think adding the namespace and OLM resource to the related objects is necessary. If we look at where the relatedObjects slice is created [here](https://github.com/openshift/cluster-olm-operator/blob/main/pkg/controller/builder.go#L89), we see that the code steps through the contents of the manifests folder. Both the namespace and OLM manifests should be in there (the latter is copied in the [Dockerfile](https://github.com/openshift/cluster-olm-operator/blob/main/Dockerfile#L10))