### PR TITLE
Revert "NO-ISSUE: Add OCP variant annotations to manifests"

### DIFF
--- a/manifests/0000_51_olm_00-olm-operator.yml
+++ b/manifests/0000_51_olm_00-olm-operator.yml
@@ -3,12 +3,13 @@ kind: OLM
 metadata:
   name: cluster
   annotations:
+    include.release.openshift.io/hypershift: "true"
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     include.release.openshift.io/single-node-developer: "true"
-    capability.openshift.io/name: "OperatorLifecycleManagerV1"
-    release.openshift.io/feature-set: TechPreviewNoUpgrade
     release.openshift.io/create-only: "true"
+    release.openshift.io/feature-set: TechPreviewNoUpgrade
+    capability.openshift.io/name: "OperatorLifecycleManagerV1"
 spec:
   managementState: Managed
   logLevel: Normal

--- a/manifests/0000_51_olm_01_operator_namespace.yaml
+++ b/manifests/0000_51_olm_01_operator_namespace.yaml
@@ -3,11 +3,9 @@ kind: Namespace
 metadata:
   name: openshift-cluster-olm-operator
   annotations:
-    include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
-    include.release.openshift.io/single-node-developer: "true"
-    capability.openshift.io/name: "OperatorLifecycleManagerV1"
+    workload.openshift.io/allowed: "management"
     release.openshift.io/feature-set: TechPreviewNoUpgrade
     pod-security.kubernetes.io/enforce: restricted
     pod-security.kubernetes.io/enforce-version: latest
-    workload.openshift.io/allowed: "management"
+    capability.openshift.io/name: "OperatorLifecycleManagerV1"

--- a/manifests/0000_51_olm_02_operator_clusterrole.yaml
+++ b/manifests/0000_51_olm_02_operator_clusterrole.yaml
@@ -3,13 +3,11 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: cluster-olm-operator
-  annotations:
-    include.release.openshift.io/ibm-cloud-managed: "true"
-    include.release.openshift.io/self-managed-high-availability: "true"
-    include.release.openshift.io/single-node-developer: "true"
-    capability.openshift.io/name: "OperatorLifecycleManagerV1"
-    release.openshift.io/feature-set: TechPreviewNoUpgrade
+    name: cluster-olm-operator
+    annotations:
+        include.release.openshift.io/self-managed-high-availability: "true"
+        release.openshift.io/feature-set: TechPreviewNoUpgrade
+        capability.openshift.io/name: "OperatorLifecycleManagerV1"
 rules:
   - apiGroups:
       - config.openshift.io

--- a/manifests/0000_51_olm_03_service_account.yaml
+++ b/manifests/0000_51_olm_03_service_account.yaml
@@ -4,8 +4,6 @@ metadata:
   namespace: openshift-cluster-olm-operator
   name: cluster-olm-operator
   annotations:
-    include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
-    include.release.openshift.io/single-node-developer: "true"
-    capability.openshift.io/name: "OperatorLifecycleManagerV1"
     release.openshift.io/feature-set: TechPreviewNoUpgrade
+    capability.openshift.io/name: "OperatorLifecycleManagerV1"

--- a/manifests/0000_51_olm_04_metrics_service.yaml
+++ b/manifests/0000_51_olm_04_metrics_service.yaml
@@ -5,12 +5,10 @@ metadata:
   namespace: openshift-cluster-olm-operator
   name: cluster-olm-operator-metrics
   annotations:
-    include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
-    include.release.openshift.io/single-node-developer: "true"
-    capability.openshift.io/name: "OperatorLifecycleManagerV1"
-    release.openshift.io/feature-set: TechPreviewNoUpgrade
     service.alpha.openshift.io/serving-cert-secret-name: cluster-olm-operator-serving-cert
+    release.openshift.io/feature-set: TechPreviewNoUpgrade
+    capability.openshift.io/name: "OperatorLifecycleManagerV1"
 spec:
   ports:
   - name: https

--- a/manifests/0000_51_olm_05_operator_clusterrolebinding.yaml
+++ b/manifests/0000_51_olm_05_operator_clusterrolebinding.yaml
@@ -3,11 +3,9 @@ apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: cluster-olm-operator-role
   annotations:
-    include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
-    include.release.openshift.io/single-node-developer: "true"
-    capability.openshift.io/name: "OperatorLifecycleManagerV1"
     release.openshift.io/feature-set: TechPreviewNoUpgrade
+    capability.openshift.io/name: "OperatorLifecycleManagerV1"
 subjects:
 - kind: ServiceAccount
   name: cluster-olm-operator

--- a/manifests/0000_51_olm_06_deployment.yaml
+++ b/manifests/0000_51_olm_06_deployment.yaml
@@ -4,11 +4,9 @@ metadata:
   namespace: openshift-cluster-olm-operator
   name: cluster-olm-operator
   annotations:
-    include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
-    include.release.openshift.io/single-node-developer: "true"
-    capability.openshift.io/name: "OperatorLifecycleManagerV1"
     release.openshift.io/feature-set: TechPreviewNoUpgrade
+    capability.openshift.io/name: "OperatorLifecycleManagerV1"
 spec:
   replicas: 1
   selector:

--- a/manifests/0000_51_olm_07_cluster_operator.yaml
+++ b/manifests/0000_51_olm_07_cluster_operator.yaml
@@ -3,11 +3,9 @@ kind: ClusterOperator
 metadata:
   name: olm
   annotations:
-    include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
-    include.release.openshift.io/single-node-developer: "true"
-    capability.openshift.io/name: "OperatorLifecycleManagerV1"
     release.openshift.io/feature-set: TechPreviewNoUpgrade
+    capability.openshift.io/name: "OperatorLifecycleManagerV1"
 spec: {}
 status:
   versions:


### PR DESCRIPTION
Reverts https://github.com/openshift/cluster-olm-operator/pull/86 ; tracked by https://issues.redhat.com/browse/OCPBUGS-44675

Per [OpenShift policy](https://github.com/openshift/enhancements/blob/master/enhancements/release/improving-ci-signal.md#quick-revert), we are reverting this breaking change to get CI and/or nightly payloads flowing again.

4.18 CI [hypershift job](https://prow.ci.openshift.org/view/gs/test-platform-results/logs/periodic-ci-openshift-hypershift-release-4.18-periodics-e2e-aws-ovn/1858489393128411136) is failing due to OLM failing to be scheduled. 


Relevant slack thread: https://redhat-internal.slack.com/archives/C01CQA76KMX/p1731943727060319


To unrevert this, revert this PR, and layer an additional separate commit on top that addresses the problem. Before merging the unrevert, please run these jobs on the PR and check the result of (job/X or job/X, test/Y tuple) to confirm the fix has corrected the problem:

/payload-job periodic-ci-openshift-hypershift-release-4.18-periodics-e2e-aws-ovn

CC: @perdasilva @joelanford 