### PR TITLE
NO-ISSUE: Add ocp variants annotations

### DIFF
--- a/manifests/0000_51_olm_00-olm-operator.yml
+++ b/manifests/0000_51_olm_00-olm-operator.yml
@@ -3,13 +3,12 @@ kind: OLM
 metadata:
   name: cluster
   annotations:
-    include.release.openshift.io/hypershift: "true"
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     include.release.openshift.io/single-node-developer: "true"
-    release.openshift.io/create-only: "true"
-    release.openshift.io/feature-set: TechPreviewNoUpgrade
     capability.openshift.io/name: "OperatorLifecycleManagerV1"
+    release.openshift.io/feature-set: TechPreviewNoUpgrade
+    release.openshift.io/create-only: "true"
 spec:
   managementState: Managed
   logLevel: Normal

--- a/manifests/0000_51_olm_00-olm-operator.yml
+++ b/manifests/0000_51_olm_00-olm-operator.yml
@@ -3,9 +3,7 @@ kind: OLM
 metadata:
   name: cluster
   annotations:
-    include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
-    include.release.openshift.io/single-node-developer: "true"
     capability.openshift.io/name: "OperatorLifecycleManagerV1"
     release.openshift.io/feature-set: TechPreviewNoUpgrade
     release.openshift.io/create-only: "true"

--- a/manifests/0000_51_olm_01_operator_namespace.yaml
+++ b/manifests/0000_51_olm_01_operator_namespace.yaml
@@ -3,9 +3,7 @@ kind: Namespace
 metadata:
   name: openshift-cluster-olm-operator
   annotations:
-    include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
-    include.release.openshift.io/single-node-developer: "true"
     capability.openshift.io/name: "OperatorLifecycleManagerV1"
     release.openshift.io/feature-set: TechPreviewNoUpgrade
     pod-security.kubernetes.io/enforce: restricted

--- a/manifests/0000_51_olm_01_operator_namespace.yaml
+++ b/manifests/0000_51_olm_01_operator_namespace.yaml
@@ -3,9 +3,11 @@ kind: Namespace
 metadata:
   name: openshift-cluster-olm-operator
   annotations:
+    include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
-    workload.openshift.io/allowed: "management"
+    include.release.openshift.io/single-node-developer: "true"
+    capability.openshift.io/name: "OperatorLifecycleManagerV1"
     release.openshift.io/feature-set: TechPreviewNoUpgrade
     pod-security.kubernetes.io/enforce: restricted
     pod-security.kubernetes.io/enforce-version: latest
-    capability.openshift.io/name: "OperatorLifecycleManagerV1"
+    workload.openshift.io/allowed: "management"

--- a/manifests/0000_51_olm_02_operator_clusterrole.yaml
+++ b/manifests/0000_51_olm_02_operator_clusterrole.yaml
@@ -3,11 +3,13 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-    name: cluster-olm-operator
-    annotations:
-        include.release.openshift.io/self-managed-high-availability: "true"
-        release.openshift.io/feature-set: TechPreviewNoUpgrade
-        capability.openshift.io/name: "OperatorLifecycleManagerV1"
+  name: cluster-olm-operator
+  annotations:
+    include.release.openshift.io/ibm-cloud-managed: "true"
+    include.release.openshift.io/self-managed-high-availability: "true"
+    include.release.openshift.io/single-node-developer: "true"
+    capability.openshift.io/name: "OperatorLifecycleManagerV1"
+    release.openshift.io/feature-set: TechPreviewNoUpgrade
 rules:
   - apiGroups:
       - config.openshift.io

--- a/manifests/0000_51_olm_02_operator_clusterrole.yaml
+++ b/manifests/0000_51_olm_02_operator_clusterrole.yaml
@@ -5,9 +5,7 @@ kind: ClusterRole
 metadata:
   name: cluster-olm-operator
   annotations:
-    include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
-    include.release.openshift.io/single-node-developer: "true"
     capability.openshift.io/name: "OperatorLifecycleManagerV1"
     release.openshift.io/feature-set: TechPreviewNoUpgrade
 rules:

--- a/manifests/0000_51_olm_03_service_account.yaml
+++ b/manifests/0000_51_olm_03_service_account.yaml
@@ -4,8 +4,6 @@ metadata:
   namespace: openshift-cluster-olm-operator
   name: cluster-olm-operator
   annotations:
-    include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
-    include.release.openshift.io/single-node-developer: "true"
     capability.openshift.io/name: "OperatorLifecycleManagerV1"
     release.openshift.io/feature-set: TechPreviewNoUpgrade

--- a/manifests/0000_51_olm_03_service_account.yaml
+++ b/manifests/0000_51_olm_03_service_account.yaml
@@ -4,6 +4,8 @@ metadata:
   namespace: openshift-cluster-olm-operator
   name: cluster-olm-operator
   annotations:
+    include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
-    release.openshift.io/feature-set: TechPreviewNoUpgrade
+    include.release.openshift.io/single-node-developer: "true"
     capability.openshift.io/name: "OperatorLifecycleManagerV1"
+    release.openshift.io/feature-set: TechPreviewNoUpgrade

--- a/manifests/0000_51_olm_04_metrics_service.yaml
+++ b/manifests/0000_51_olm_04_metrics_service.yaml
@@ -5,9 +5,7 @@ metadata:
   namespace: openshift-cluster-olm-operator
   name: cluster-olm-operator-metrics
   annotations:
-    include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
-    include.release.openshift.io/single-node-developer: "true"
     capability.openshift.io/name: "OperatorLifecycleManagerV1"
     release.openshift.io/feature-set: TechPreviewNoUpgrade
     service.alpha.openshift.io/serving-cert-secret-name: cluster-olm-operator-serving-cert

--- a/manifests/0000_51_olm_04_metrics_service.yaml
+++ b/manifests/0000_51_olm_04_metrics_service.yaml
@@ -5,10 +5,12 @@ metadata:
   namespace: openshift-cluster-olm-operator
   name: cluster-olm-operator-metrics
   annotations:
+    include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
-    service.alpha.openshift.io/serving-cert-secret-name: cluster-olm-operator-serving-cert
-    release.openshift.io/feature-set: TechPreviewNoUpgrade
+    include.release.openshift.io/single-node-developer: "true"
     capability.openshift.io/name: "OperatorLifecycleManagerV1"
+    release.openshift.io/feature-set: TechPreviewNoUpgrade
+    service.alpha.openshift.io/serving-cert-secret-name: cluster-olm-operator-serving-cert
 spec:
   ports:
   - name: https

--- a/manifests/0000_51_olm_05_operator_clusterrolebinding.yaml
+++ b/manifests/0000_51_olm_05_operator_clusterrolebinding.yaml
@@ -3,9 +3,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: cluster-olm-operator-role
   annotations:
-    include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
-    include.release.openshift.io/single-node-developer: "true"
     capability.openshift.io/name: "OperatorLifecycleManagerV1"
     release.openshift.io/feature-set: TechPreviewNoUpgrade
 subjects:

--- a/manifests/0000_51_olm_05_operator_clusterrolebinding.yaml
+++ b/manifests/0000_51_olm_05_operator_clusterrolebinding.yaml
@@ -3,9 +3,11 @@ apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: cluster-olm-operator-role
   annotations:
+    include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
-    release.openshift.io/feature-set: TechPreviewNoUpgrade
+    include.release.openshift.io/single-node-developer: "true"
     capability.openshift.io/name: "OperatorLifecycleManagerV1"
+    release.openshift.io/feature-set: TechPreviewNoUpgrade
 subjects:
 - kind: ServiceAccount
   name: cluster-olm-operator

--- a/manifests/0000_51_olm_06_deployment.yaml
+++ b/manifests/0000_51_olm_06_deployment.yaml
@@ -4,9 +4,11 @@ metadata:
   namespace: openshift-cluster-olm-operator
   name: cluster-olm-operator
   annotations:
+    include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
-    release.openshift.io/feature-set: TechPreviewNoUpgrade
+    include.release.openshift.io/single-node-developer: "true"
     capability.openshift.io/name: "OperatorLifecycleManagerV1"
+    release.openshift.io/feature-set: TechPreviewNoUpgrade
 spec:
   replicas: 1
   selector:

--- a/manifests/0000_51_olm_06_deployment.yaml
+++ b/manifests/0000_51_olm_06_deployment.yaml
@@ -4,9 +4,7 @@ metadata:
   namespace: openshift-cluster-olm-operator
   name: cluster-olm-operator
   annotations:
-    include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
-    include.release.openshift.io/single-node-developer: "true"
     capability.openshift.io/name: "OperatorLifecycleManagerV1"
     release.openshift.io/feature-set: TechPreviewNoUpgrade
 spec:

--- a/manifests/0000_51_olm_07_cluster_operator.yaml
+++ b/manifests/0000_51_olm_07_cluster_operator.yaml
@@ -3,9 +3,7 @@ kind: ClusterOperator
 metadata:
   name: olm
   annotations:
-    include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
-    include.release.openshift.io/single-node-developer: "true"
     capability.openshift.io/name: "OperatorLifecycleManagerV1"
     release.openshift.io/feature-set: TechPreviewNoUpgrade
 spec: {}

--- a/manifests/0000_51_olm_07_cluster_operator.yaml
+++ b/manifests/0000_51_olm_07_cluster_operator.yaml
@@ -3,9 +3,11 @@ kind: ClusterOperator
 metadata:
   name: olm
   annotations:
+    include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
-    release.openshift.io/feature-set: TechPreviewNoUpgrade
+    include.release.openshift.io/single-node-developer: "true"
     capability.openshift.io/name: "OperatorLifecycleManagerV1"
+    release.openshift.io/feature-set: TechPreviewNoUpgrade
 spec: {}
 status:
   versions:


### PR DESCRIPTION
This PR reverts https://github.com/openshift/cluster-olm-operator/pull/87 and adds a commit to fix the issue which was breaking hypershift tech-preview jobs

https://github.com/openshift/cluster-olm-operator/pull/87 was a revert of https://github.com/openshift/cluster-olm-operator/pull/86