### PR TITLE
OCPBUGS-45098: Add infomer for proxy.config.openshift.io

### DIFF
--- a/manifests/0000_51_olm_02_operator_clusterrole.yaml
+++ b/manifests/0000_51_olm_02_operator_clusterrole.yaml
@@ -12,6 +12,7 @@ rules:
       - config.openshift.io
     resources:
       - infrastructures
+      - proxies
     verbs:
       - get
       - list

--- a/pkg/controller/proxycontroller.go
+++ b/pkg/controller/proxycontroller.go
@@ -1,0 +1,87 @@
+package controller
+
+import (
+	"context"
+	"fmt"
+	"os"
+
+	"github.com/go-logr/logr"
+	"github.com/openshift/library-go/pkg/controller/factory"
+	"github.com/openshift/library-go/pkg/operator/events"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/klog/v2"
+
+	"github.com/openshift/cluster-olm-operator/pkg/clients"
+)
+
+const (
+	HTTPProxy  = "HTTP_PROXY"
+	HTTPSProxy = "HTTPS_PROXY"
+	NoProxy    = "NO_PROXY"
+)
+
+func NewProxyController(name string, proxyClient *clients.ProxyClient, operatorClient *clients.OperatorClient, eventRecorder events.Recorder) factory.Controller {
+	c := proxyController{
+		name:        name,
+		proxyClient: proxyClient,
+	}
+
+	return factory.New().WithSync(c.sync).WithSyncDegradedOnError(operatorClient).WithInformers(proxyClient.Informer()).ToController(name, eventRecorder)
+}
+
+type proxyController struct {
+	name        string
+	proxyClient *clients.ProxyClient
+}
+
+func (c *proxyController) sync(ctx context.Context, _ factory.SyncContext) error {
+	logger := klog.FromContext(ctx).WithName(c.name).V(1)
+	logger.Info("sync started")
+	defer logger.Info("sync finished")
+
+	return UpdateProxyEnvironment(logger, c.proxyClient)
+}
+
+func UpdateProxyEnvironment(logger logr.Logger, pc clients.ProxyClientInterface) error {
+	logger.Info("getting proxy configuration")
+	proxySpec, err := pc.Get("cluster")
+	if err != nil {
+		if apierrors.IsNotFound(err) {
+			logger.Info("proxy configuration not found")
+			updateEnvironment(logger, map[string]string{
+				HTTPProxy:  "",
+				HTTPSProxy: "",
+				NoProxy:    "",
+			})
+			return nil
+		}
+		return fmt.Errorf("failed to get proxy: %w", err)
+	}
+
+	logger.Info("updating environment")
+	updateEnvironment(logger, map[string]string{
+		HTTPProxy:  proxySpec.Status.HTTPProxy,
+		HTTPSProxy: proxySpec.Status.HTTPSProxy,
+		NoProxy:    proxySpec.Status.NoProxy,
+	})
+	return nil
+}
+
+// Updates the local environment and returns true if changed, false if unchanged
+// if newValue is "", then the environment variables is unset
+// An unset or empty variables are considered to have the same value
+func updateEnvironment(logger logr.Logger, env map[string]string) {
+	for envVar, newValue := range env {
+		oldValue := os.Getenv(envVar)
+		if newValue == "" {
+			os.Unsetenv(envVar)
+		} else {
+			os.Setenv(envVar, newValue)
+		}
+		if newValue != oldValue {
+			logger.Info("Updated environment", "key", envVar, "old", oldValue, "new", newValue)
+		} else {
+			logger.Info("Unchanged environment", "key", envVar, "value", oldValue)
+		}
+	}
+}

--- a/pkg/controller/proxycontroller_test.go
+++ b/pkg/controller/proxycontroller_test.go
@@ -1,0 +1,60 @@
+package controller_test
+
+import (
+	"os"
+	"testing"
+
+	"github.com/go-logr/logr"
+	configv1 "github.com/openshift/api/config/v1"
+	"github.com/openshift/cluster-olm-operator/pkg/controller"
+)
+
+func TestProxyController(t *testing.T) {
+	testdata := []controller.MockProxyClient{
+		{
+			Proxy: configv1.Proxy{
+				Status: configv1.ProxyStatus{
+					HTTPProxy:  controller.HTTPProxy,
+					HTTPSProxy: controller.HTTPSProxy,
+					NoProxy:    controller.NoProxy,
+				},
+			},
+		},
+		{
+			Proxy: configv1.Proxy{},
+		},
+	}
+
+	for _, test := range testdata {
+		logger := logr.New(nil)
+		pc := test
+		err := controller.UpdateProxyEnvironment(logger, &pc)
+		if err != nil {
+			t.Fatalf("UpdateProxyEnvironment() failed: %v", err)
+		}
+
+		v, ok := os.LookupEnv(controller.HTTPProxy)
+		if ok == (test.Status.HTTPProxy == "") {
+			t.Fatalf("HttpProxy unexpected ok value: %v", ok)
+		}
+		if v != test.Status.HTTPProxy {
+			t.Fatalf("HttpProxy expected value %q to be %q", v, test.Status.HTTPProxy)
+		}
+
+		v, ok = os.LookupEnv(controller.HTTPSProxy)
+		if ok == (test.Status.HTTPSProxy == "") {
+			t.Fatalf("HttpsProxy unexpected ok value: %v", ok)
+		}
+		if v != test.Status.HTTPSProxy {
+			t.Fatalf("HttpsProxy expected value %q to be %q", v, test.Status.HTTPSProxy)
+		}
+
+		v, ok = os.LookupEnv(controller.NoProxy)
+		if ok == (test.Status.NoProxy == "") {
+			t.Fatalf("NoProxy unexpected ok value: %v", ok)
+		}
+		if v != test.Status.NoProxy {
+			t.Fatalf("NoProxy expected value %q to be %q", v, test.Status.NoProxy)
+		}
+	}
+}


### PR DESCRIPTION
Update the environment of the cluster-olm-operator
Update the env of the catalogd/operator-controller deployments