### PR TITLE
OPRUN-3663:  Watch and reconcile feature gates changes

### DIFF
--- a/internal/featuregates/mapper.go
+++ b/internal/featuregates/mapper.go
@@ -1,0 +1,105 @@
+package featuregates
+
+import (
+	"bytes"
+	"errors"
+	"strings"
+
+	configv1 "github.com/openshift/api/config/v1"
+	"github.com/openshift/api/features"
+)
+
+// Add your new upstream feature gate here
+// const (
+// 		MyUpstreamFeature = "MyUpstreamFeature"
+// )
+
+type MapperInterface interface {
+	OperatorControllerUpstreamForDownstream(downstreamGate configv1.FeatureGateName) []string
+	OperatorControllerDownstreamFeatureGates() []configv1.FeatureGateName
+	CatalogdUpstreamForDownstream(downstreamGate configv1.FeatureGateName) []string
+	CatalogdDownstreamFeatureGates() []configv1.FeatureGateName
+}
+
+// Mapper knows the mapping between downstream and upstream feature gates for both OLM components
+type Mapper struct {
+	operatorControllerGates map[configv1.FeatureGateName][]string
+	catalogdGates           map[configv1.FeatureGateName][]string
+}
+
+func NewMapper() *Mapper {
+	// Add your downstream to upstream mapping here
+	operatorControllerGates := map[configv1.FeatureGateName][]string{
+		// features.FeatureGateNewOLMMyDownstreamFeature: {MyUpstreamControllerOperatorFeature}
+	}
+	catalogdGates := map[configv1.FeatureGateName][]string{
+		// features.FeatureGateNewOLMMyDownstreamFeature: {MyUpstreamCatalogdFeature}
+	}
+
+	for _, m := range []map[configv1.FeatureGateName][]string{operatorControllerGates, catalogdGates} {
+		for downstreamGate := range m {
+			// features.FeatureGateNewOLM is a GA-enabled downstream feature gate.
+			// If there is a need to enable upstream alpha/beta features in the downstream GA release
+			// get approval via a merged openshift/enhancement describing the need, then carve out
+			// an exception in this failsafe code
+			if downstreamGate == features.FeatureGateNewOLM {
+				panic(errors.New("FeatureGateNewOLM used in mappings"))
+			}
+			if !strings.HasPrefix(string(downstreamGate), string(features.FeatureGateNewOLM)) {
+				panic(errors.New("all downstream feature gates must use NewOLM prefix by convention"))
+			}
+		}
+	}
+
+	return &Mapper{operatorControllerGates: operatorControllerGates, catalogdGates: catalogdGates}
+}
+
+// OperatorControllerDownstreamFeatureGates returns a list of all downstream feature gates
+// which have an upstream mapping configured for the operator-controller component
+func (m *Mapper) OperatorControllerDownstreamFeatureGates() []configv1.FeatureGateName {
+	return getKeys(m.operatorControllerGates)
+}
+
+// CatalogdDownstreamFeatureGates returns a list of all downstream feature gates
+// which have an upstream mapping configured for the catalogd component
+func (m *Mapper) CatalogdDownstreamFeatureGates() []configv1.FeatureGateName {
+	return getKeys(m.catalogdGates)
+}
+
+// OperatorControllerUpstreamForDownstream returns upstream feature gates which are configured
+// for a given downstream feature gate for the operator-controller component
+func (m *Mapper) OperatorControllerUpstreamForDownstream(downstreamGate configv1.FeatureGateName) []string {
+	return m.operatorControllerGates[downstreamGate]
+}
+
+// CatalogdUpstreamForDownstream returns upstream feature gates which are configured
+// for a given downstream feature gate for the catalogd component
+func (m *Mapper) CatalogdUpstreamForDownstream(downstreamGate configv1.FeatureGateName) []string {
+	return m.catalogdGates[downstreamGate]
+}
+
+// FormatAsEnabledArgs combines list of feature gate names into
+// an all-enabled arg format of <feature_gate_name1>=true,<feature_gate_name1>=true etc.
+func FormatAsEnabledArgs(enabledFeatureGates []string) string {
+	buf := bytes.Buffer{}
+	for _, gateName := range enabledFeatureGates {
+		buf.WriteString(gateName)
+		buf.WriteRune('=')
+		buf.WriteString("true")
+		buf.WriteRune(',')
+	}
+	if buf.Len() > 0 {
+		// get rid of trailing ','
+		buf.Truncate(buf.Len() - 1)
+	}
+
+	return buf.String()
+}
+
+func getKeys(m map[configv1.FeatureGateName][]string) []configv1.FeatureGateName {
+	keys := make([]configv1.FeatureGateName, 0, len(m))
+	for k := range m {
+		keys = append(keys, k)
+	}
+	return keys
+}

--- a/internal/featuregates/mapper_test.go
+++ b/internal/featuregates/mapper_test.go
@@ -1,0 +1,73 @@
+package featuregates
+
+import (
+	"slices"
+	"testing"
+
+	configv1 "github.com/openshift/api/config/v1"
+	"github.com/openshift/api/features"
+)
+
+func TestMapper_ControllerUpstreamForDownstream(t *testing.T) {
+	t.Run("returns mapped upstream gates for operator-controller", func(t *testing.T) {
+		expectedUpstreamGates := []string{"HelloGate", "WorldGate"}
+
+		mapper := NewMapper()
+		mapper.operatorControllerGates = map[configv1.FeatureGateName][]string{
+			features.FeatureGateNewOLM: expectedUpstreamGates,
+		}
+		upstream := mapper.OperatorControllerUpstreamForDownstream(features.FeatureGateNewOLM)
+		if !slices.Equal(upstream, expectedUpstreamGates) {
+			t.Fatalf("expected and returned upstream gates differ: upstream: %+v, expected: %+v",
+				upstream, expectedUpstreamGates,
+			)
+		}
+	})
+}
+
+func TestMapper_CatalogdUpstreamForDownstream(t *testing.T) {
+	t.Run("returns mapped upstream gates for catalogd", func(t *testing.T) {
+		expectedUpstreamGates := []string{"HelloGate", "WorldGate"}
+
+		mapper := NewMapper()
+		mapper.catalogdGates = map[configv1.FeatureGateName][]string{
+			features.FeatureGateNewOLM: expectedUpstreamGates,
+		}
+		upstream := mapper.CatalogdUpstreamForDownstream(features.FeatureGateNewOLM)
+		if !slices.Equal(upstream, expectedUpstreamGates) {
+			t.Fatalf("expected and returned upstream gates differ: upstream: %+v, expected: %+v",
+				upstream, expectedUpstreamGates,
+			)
+		}
+	})
+}
+
+func TestFormatAsEnabledArgs(t *testing.T) {
+	testCases := []struct {
+		name     string
+		in       []string
+		expected string
+	}{
+		{
+			name: "empty",
+		},
+		{
+			name:     "single feature gate",
+			in:       []string{"testGate1"},
+			expected: "testGate1=true",
+		},
+		{
+			name:     "multiple feature gates",
+			in:       []string{"testGate1", "testGate2", "testGate3"},
+			expected: "testGate1=true,testGate2=true,testGate2=true",
+		},
+	}
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			result := FormatAsEnabledArgs(testCase.in)
+			if result != testCase.expected {
+				t.Fatalf("result and expected differ, expected: %q, got: %q", testCase.expected, result)
+			}
+		})
+	}
+}

--- a/manifests/0000_51_olm_02_operator_clusterrole.yaml
+++ b/manifests/0000_51_olm_02_operator_clusterrole.yaml
@@ -13,6 +13,8 @@ rules:
     resources:
       - infrastructures
       - proxies
+      - featuregates
+      - clusterversions
     verbs:
       - get
       - list

--- a/pkg/clients/clients.go
+++ b/pkg/clients/clients.go
@@ -21,11 +21,16 @@ import (
 	operatorv1apply "github.com/openshift/client-go/operator/applyconfigurations/operator/v1"
 	operatorclient "github.com/openshift/client-go/operator/clientset/versioned"
 	operatorinformers "github.com/openshift/client-go/operator/informers/externalversions"
+	internalfeatures "github.com/openshift/cluster-olm-operator/internal/featuregates"
 	"github.com/openshift/library-go/pkg/apiserver/jsonpatch"
 	"github.com/openshift/library-go/pkg/controller/controllercmd"
+	"github.com/openshift/library-go/pkg/operator/configobserver/featuregates"
+	"github.com/openshift/library-go/pkg/operator/events"
 	"github.com/openshift/library-go/pkg/operator/resource/resourceapply"
+	"github.com/openshift/library-go/pkg/operator/status"
 	"github.com/openshift/library-go/pkg/operator/v1helpers"
 	ocv1 "github.com/operator-framework/operator-controller/api/v1"
+	corev1 "k8s.io/api/core/v1"
 	apiextensionsclient "k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset"
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -62,6 +67,8 @@ type Clients struct {
 	KubeInformerFactory        informers.SharedInformerFactory
 	ConfigInformerFactory      configinformer.SharedInformerFactory
 	KubeInformersForNamespaces v1helpers.KubeInformersForNamespaces
+	FeatureGatesAccessor       featuregates.FeatureGateAccess
+	FeatureGateMapper          internalfeatures.MapperInterface
 }
 
 func New(cc *controllercmd.ControllerContext) (*Clients, error) {
@@ -122,10 +129,13 @@ func New(cc *controllercmd.ControllerContext) (*Clients, error) {
 		ConfigClient:           configClient,
 		KubeInformerFactory:    informers.NewSharedInformerFactory(kubeClient, defaultResyncPeriod),
 		ConfigInformerFactory:  configInformerFactory,
+		FeatureGatesAccessor:   setupFeatureGatesAccessor(kubeClient, configInformerFactory, cc.OperatorNamespace),
+		FeatureGateMapper:      internalfeatures.NewMapper(),
 	}, nil
 }
 
 func (c *Clients) StartInformers(ctx context.Context) {
+	go c.FeatureGatesAccessor.Run(ctx)
 	c.KubeInformerFactory.Start(ctx.Done())
 	c.ConfigInformerFactory.Start(ctx.Done())
 	c.OperatorInformers.Start(ctx.Done())
@@ -146,6 +156,38 @@ func (c *Clients) ClientHolder() *resourceapply.ClientHolder {
 		cl = cl.WithKubernetesInformers(c.KubeInformersForNamespaces)
 	}
 	return cl
+}
+
+func setupFeatureGatesAccessor(
+	kubeClient *kubernetes.Clientset,
+	configInformerFactory configinformer.SharedInformerFactory,
+	operatorNamespace string,
+) featuregates.FeatureGateAccess {
+	eventRecorder := events.NewKubeRecorder(
+		kubeClient.CoreV1().Events(operatorNamespace),
+		"cluster-olm-operator",
+		&corev1.ObjectReference{
+			APIVersion: "apps/v1",
+			Kind:       "Deployment",
+			Namespace:  operatorNamespace,
+			Name:       "cluster-olm-operator",
+		},
+	)
+
+	operatorImageVersion := status.VersionForOperatorFromEnv()
+	missingVersion := "0.0.1-snapshot"
+	featureGateAccessor := featuregates.NewFeatureGateAccess(
+		operatorImageVersion,
+		missingVersion,
+		configInformerFactory.Config().V1().ClusterVersions(), configInformerFactory.Config().V1().FeatureGates(),
+		eventRecorder,
+	)
+	// modify the default behavior of calling exit(0) to noop whenever a FeatureGates set changes in cluster
+	// reconsider this change if there ever comes a feature flag that affects the cluster-olm-operator directly
+	// see: https://github.com/openshift/cluster-olm-operator/pull/102#discussion_r1926861888
+	featureGateAccessor.SetChangeHandler(func(_ featuregates.FeatureChange) {})
+
+	return featureGateAccessor
 }
 
 var _ v1helpers.OperatorClientWithFinalizers = &OperatorClient{}

--- a/pkg/controller/builder_test.go
+++ b/pkg/controller/builder_test.go
@@ -81,7 +81,7 @@ func (m *MockProxyClient) Get(_ string) (*configv1.Proxy, error) {
 	return &m.Proxy, nil
 }
 
-func TestUpdateEnv(t *testing.T) {
+func TestProxyUpdateEnv(t *testing.T) {
 	mpc := MockProxyClient{
 		Proxy: configv1.Proxy{
 			Status: configv1.ProxyStatus{
@@ -115,25 +115,26 @@ func TestUpdateEnv(t *testing.T) {
 		t.Fatalf("environment length not 3: %+v", dep)
 	}
 
-	check := func() {
-		// We want to make sure the order is preserved, so check explicitly
-		vars := []corev1.EnvVar{
-			{Name: HTTPSProxy, Value: HTTPSProxy},
-			{Name: HTTPProxy, Value: HTTPProxy},
-			{Name: NoProxy, Value: NoProxy},
-		}
-		for i := range vars {
-			if vars[i] != dep.Spec.Template.Spec.Containers[0].Env[i] {
-				t.Fatalf("iter %d: expected: %+v, got: %+v", i, vars[i], dep.Spec.Template.Spec.Containers[0].Env[i])
-			}
-		}
+	// We want to make sure the order is preserved, so check explicitly
+	expectedVars := []corev1.EnvVar{
+		{Name: HTTPSProxy, Value: HTTPSProxy},
+		{Name: HTTPProxy, Value: HTTPProxy},
+		{Name: NoProxy, Value: NoProxy},
 	}
-	check()
+	validateEnvVarsOrFail(t, expectedVars, dep.Spec.Template.Spec.Containers[0].Env)
 
 	err = update(nil, &dep)
 	if err == nil {
 		t.Fatal("no error in second update")
 	}
 	// Make sure the Deployment is unchanged
-	check()
+	validateEnvVarsOrFail(t, expectedVars, dep.Spec.Template.Spec.Containers[0].Env)
+}
+
+func validateEnvVarsOrFail(t *testing.T, in, expected []corev1.EnvVar) {
+	for i := range in {
+		if in[i] != expected[i] {
+			t.Fatalf("iter %d: expected: %+v, got: %+v", i, in[i], expected[i])
+		}
+	}
 }

--- a/pkg/controller/featuregates_hook.go
+++ b/pkg/controller/featuregates_hook.go
@@ -1,0 +1,107 @@
+package controller
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"slices"
+	"strings"
+
+	configv1 "github.com/openshift/api/config/v1"
+	operatorv1 "github.com/openshift/api/operator/v1"
+	internalfeatures "github.com/openshift/cluster-olm-operator/internal/featuregates"
+	"github.com/openshift/library-go/pkg/operator/configobserver/featuregates"
+	"github.com/openshift/library-go/pkg/operator/deploymentcontroller"
+	appsv1 "k8s.io/api/apps/v1"
+	"k8s.io/klog/v2"
+)
+
+const (
+	operatorControllerDeploymentName = "operator-controller-controller-manager"
+	catalogdDeploymentName           = "catalogd-controller-manager"
+)
+
+// UpdateDeploymentFeatureGatesHook handles setting --feature-gates container argument
+// on 'manager' containers for both OLM deployments - catalogd and operator-controller
+// with appropriate enabled feature gates
+func UpdateDeploymentFeatureGatesHook(
+	featuresAccessor featuregates.FeatureGateAccess,
+	featuresMapper internalfeatures.MapperInterface,
+) deploymentcontroller.DeploymentHookFunc {
+	return func(_ *operatorv1.OperatorSpec, deployment *appsv1.Deployment) error {
+		logger := klog.FromContext(context.Background()).WithName("feature_gates_hook")
+		logger.V(0).Info("updating environment", "deployment", deployment.Name)
+
+		clusterGatesConfig, err := featuresAccessor.CurrentFeatureGates()
+		if err != nil {
+			return fmt.Errorf("error getting featuregates.config.openshift.io/cluster: %w", err)
+		}
+
+		var upstreamGates []string
+		switch deployment.Name {
+		case operatorControllerDeploymentName:
+			upstreamGates = upstreamFeatureGates(
+				clusterGatesConfig,
+				featuresMapper.OperatorControllerDownstreamFeatureGates(),
+				featuresMapper.OperatorControllerUpstreamForDownstream,
+			)
+		case catalogdDeploymentName:
+			upstreamGates = upstreamFeatureGates(
+				clusterGatesConfig,
+				featuresMapper.CatalogdDownstreamFeatureGates(),
+				featuresMapper.CatalogdUpstreamForDownstream,
+			)
+		default:
+			logger.V(4).Info("unrecognized deployment", "deployment", deployment.Name)
+			return nil
+		}
+		logger.V(4).Info("enabled feature gates", "feature gates", upstreamGates, "deployment", deployment.Name)
+
+		argToSet := internalfeatures.FormatAsEnabledArgs(upstreamGates)
+		var errs []error
+		for i := range deployment.Spec.Template.Spec.Containers {
+			logger.V(4).Info("iterating containers", "container", deployment.Spec.Template.Spec.Containers[i].Name, "deployment", deployment.Name)
+			if !strings.EqualFold(deployment.Spec.Template.Spec.Containers[i].Name, "manager") {
+				continue
+			}
+			err = setContainerArg(&deployment.Spec.Template.Spec.Containers[i], "--feature-gates", argToSet)
+			if err != nil {
+				errs = append(errs, err)
+			}
+		}
+		if len(errs) > 0 {
+			return errors.Join(errs...)
+		}
+
+		return nil
+	}
+}
+
+// upstreamFeatureGates build and returns a unique and ordered list of upstream feature gates names
+// that map to the provided enabled downstream feature gates
+func upstreamFeatureGates(
+	clusterGatesConfig featuregates.FeatureGate,
+	downstreamGates []configv1.FeatureGateName,
+	downstreamToUpstreamFunc func(configv1.FeatureGateName) []string,
+) []string {
+	var upstreamGates []string
+
+	seen := make(map[string]struct{})
+	for _, downstreamGate := range downstreamGates {
+		if !clusterGatesConfig.Enabled(downstreamGate) {
+			continue
+		}
+
+		for _, upstreamGate := range downstreamToUpstreamFunc(downstreamGate) {
+			if _, found := seen[upstreamGate]; found {
+				continue
+			}
+
+			seen[upstreamGate] = struct{}{}
+			upstreamGates = append(upstreamGates, upstreamGate)
+		}
+	}
+	slices.Sort(upstreamGates)
+
+	return upstreamGates
+}

--- a/pkg/controller/featuregates_hook_test.go
+++ b/pkg/controller/featuregates_hook_test.go
@@ -1,0 +1,396 @@
+package controller_test
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	configv1 "github.com/openshift/api/config/v1"
+	"github.com/openshift/api/features"
+	"github.com/openshift/cluster-olm-operator/pkg/controller"
+	"github.com/openshift/library-go/pkg/operator/configobserver/featuregates"
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+)
+
+const (
+	operatorControllerDeploymentName = "operator-controller-controller-manager"
+	catalogdDeploymentName           = "catalogd-controller-manager"
+)
+
+type MockFeatureGateAccessor struct {
+	featureGate featuregates.FeatureGate
+	err         error
+}
+
+func (ma *MockFeatureGateAccessor) SetChangeHandler(_ featuregates.FeatureGateChangeHandlerFunc) {}
+func (ma *MockFeatureGateAccessor) Run(_ context.Context)                                        {}
+func (ma *MockFeatureGateAccessor) InitialFeatureGatesObserved() <-chan struct{}                 { return nil }
+func (ma *MockFeatureGateAccessor) AreInitialFeatureGatesObserved() bool                         { return false }
+func (ma *MockFeatureGateAccessor) CurrentFeatureGates() (featuregates.FeatureGate, error) {
+	return ma.featureGate, ma.err
+}
+
+type MockFeatureGateMapper struct {
+	ctrlOut               []string
+	ctrlDownstreamKeys    []configv1.FeatureGateName
+	ctrlUpForDownCalls    int
+	ctrlFeatureGatesCalls int
+
+	catalogOut               []string
+	catalogDownstreamKeys    []configv1.FeatureGateName
+	catalogUpForDownCalls    int
+	catalogFeatureGatesCalls int
+}
+
+func (mm *MockFeatureGateMapper) OperatorControllerUpstreamForDownstream(_ configv1.FeatureGateName) []string {
+	mm.ctrlUpForDownCalls++
+	return mm.ctrlOut
+}
+func (mm *MockFeatureGateMapper) OperatorControllerDownstreamFeatureGates() []configv1.FeatureGateName {
+	mm.ctrlFeatureGatesCalls++
+	return mm.ctrlDownstreamKeys
+}
+func (mm *MockFeatureGateMapper) CatalogdUpstreamForDownstream(_ configv1.FeatureGateName) []string {
+	mm.catalogUpForDownCalls++
+	return mm.catalogOut
+}
+func (mm *MockFeatureGateMapper) CatalogdDownstreamFeatureGates() []configv1.FeatureGateName {
+	mm.catalogFeatureGatesCalls++
+	return mm.catalogDownstreamKeys
+}
+
+func (mm *MockFeatureGateMapper) ValidateCalls(t *testing.T, ctrlUpDown, ctrlList, catalogUpDown, catalogList int) {
+	if ctrlUpDown != mm.ctrlUpForDownCalls {
+		t.Fatalf("expected %d calls to ControllerUpstreamForDownstream, got %d", mm.ctrlUpForDownCalls, ctrlUpDown)
+	}
+	if ctrlList != mm.ctrlFeatureGatesCalls {
+		t.Fatalf("expected %d calls to ControllerDownstreamFeatureGates, got %d", mm.ctrlFeatureGatesCalls, ctrlList)
+	}
+	if catalogUpDown != mm.catalogUpForDownCalls {
+		t.Fatalf("expected %d calls to CatalogdUpstreamForDownstream, got %d", mm.catalogUpForDownCalls, catalogUpDown)
+	}
+	if catalogList != mm.catalogFeatureGatesCalls {
+		t.Fatalf("expected %d calls to CatalogdDownstreamFeatureGates, got %d", mm.ctrlFeatureGatesCalls, catalogList)
+	}
+}
+
+func TestUpdateDeploymentFeatureGatesHook(t *testing.T) {
+	testDep := appsv1.Deployment{
+		Spec: appsv1.DeploymentSpec{
+			Template: corev1.PodTemplateSpec{
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{
+						{
+							Name: "test",
+						},
+					},
+				},
+			},
+		},
+	}
+
+	t.Run("Fails because of FeatureGateAccessor error", func(t *testing.T) {
+		dep := testDep.DeepCopy()
+
+		mockAccessor := &MockFeatureGateAccessor{
+			featureGate: featuregates.NewFeatureGate(
+				[]configv1.FeatureGateName{}, []configv1.FeatureGateName{features.FeatureGateNewOLM},
+			),
+			err: errors.New("fail"),
+		}
+		mockMapper := &MockFeatureGateMapper{}
+
+		update := controller.UpdateDeploymentFeatureGatesHook(mockAccessor, mockMapper)
+		err := update(nil, dep)
+		if err == nil {
+			t.Fatalf("expected error but got nil")
+		}
+		mockMapper.ValidateCalls(t, 0, 0, 0, 0)
+	})
+
+	t.Run("unrecognized deployment name - no-op", func(t *testing.T) {
+		dep := testDep.DeepCopy()
+		dep.Name = "unrecognized"
+
+		mockAccessor := &MockFeatureGateAccessor{
+			featureGate: featuregates.NewFeatureGate(
+				[]configv1.FeatureGateName{features.FeatureGateNewOLM}, []configv1.FeatureGateName{},
+			),
+			err: nil,
+		}
+		mockMapper := &MockFeatureGateMapper{}
+
+		update := controller.UpdateDeploymentFeatureGatesHook(mockAccessor, mockMapper)
+		err := update(nil, dep)
+		if err != nil {
+			t.Fatalf("unexpected error in first update: %v", err)
+		}
+		if len(dep.Spec.Template.Spec.Containers[0].Args) != 0 {
+			t.Fatalf("args length not 0: %+v", dep)
+		}
+		mockMapper.ValidateCalls(t, 0, 0, 0, 0)
+	})
+
+	t.Run("controller mapping exists, but no enabled features - no-op", func(t *testing.T) {
+		dep := testDep.DeepCopy()
+		dep.Name = operatorControllerDeploymentName
+
+		mockAccessor := &MockFeatureGateAccessor{
+			featureGate: featuregates.NewFeatureGate(
+				[]configv1.FeatureGateName{}, []configv1.FeatureGateName{features.FeatureGateNewOLM},
+			),
+			err: nil,
+		}
+		mockMapper := &MockFeatureGateMapper{ctrlDownstreamKeys: []configv1.FeatureGateName{features.FeatureGateNewOLM}}
+
+		update := controller.UpdateDeploymentFeatureGatesHook(mockAccessor, mockMapper)
+		err := update(nil, dep)
+		if err != nil {
+			t.Fatalf("unexpected error in first update: %v", err)
+		}
+		if len(dep.Spec.Template.Spec.Containers[0].Args) != 0 {
+			t.Fatalf("args length not 0: %+v", dep)
+		}
+		mockMapper.ValidateCalls(t, 0, 1, 0, 0)
+	})
+
+	t.Run("catalogd mapping exists, but no enabled features - no-op", func(t *testing.T) {
+		dep := testDep.DeepCopy()
+		dep.Name = catalogdDeploymentName
+
+		mockAccessor := &MockFeatureGateAccessor{
+			featureGate: featuregates.NewFeatureGate(
+				[]configv1.FeatureGateName{}, []configv1.FeatureGateName{features.FeatureGateNewOLM},
+			),
+			err: nil,
+		}
+		mockMapper := &MockFeatureGateMapper{catalogDownstreamKeys: []configv1.FeatureGateName{features.FeatureGateNewOLM}}
+
+		update := controller.UpdateDeploymentFeatureGatesHook(mockAccessor, mockMapper)
+		err := update(nil, dep)
+		if err != nil {
+			t.Fatalf("unexpected error in first update: %v", err)
+		}
+		if len(dep.Spec.Template.Spec.Containers[0].Args) != 0 {
+			t.Fatalf("args length not 0: %+v", dep)
+		}
+		mockMapper.ValidateCalls(t, 0, 0, 0, 1)
+	})
+
+	t.Run("controller mapping exists with enabled features, but no matching containers - no-op", func(t *testing.T) {
+		dep := testDep.DeepCopy()
+		dep.Name = operatorControllerDeploymentName
+
+		enabledFeatures := []configv1.FeatureGateName{features.FeatureGateNewOLM}
+		mockAccessor := &MockFeatureGateAccessor{
+			featureGate: featuregates.NewFeatureGate(
+				enabledFeatures, []configv1.FeatureGateName{},
+			),
+			err: nil,
+		}
+		mockMapper := &MockFeatureGateMapper{ctrlDownstreamKeys: enabledFeatures}
+
+		update := controller.UpdateDeploymentFeatureGatesHook(mockAccessor, mockMapper)
+		err := update(nil, dep)
+		if err != nil {
+			t.Fatalf("unexpected error in first update: %v", err)
+		}
+		if len(dep.Spec.Template.Spec.Containers[0].Args) != 0 {
+			t.Fatalf("args length not 0: %+v", dep)
+		}
+		mockMapper.ValidateCalls(t, 1, 1, 0, 0)
+	})
+
+	t.Run("catalog mapping exists with enabled features, but no matching containers - no-op", func(t *testing.T) {
+		dep := testDep.DeepCopy()
+		dep.Name = catalogdDeploymentName
+
+		enabledFeatures := []configv1.FeatureGateName{features.FeatureGateNewOLM}
+		mockAccessor := &MockFeatureGateAccessor{
+			featureGate: featuregates.NewFeatureGate(
+				enabledFeatures, []configv1.FeatureGateName{},
+			),
+			err: nil,
+		}
+		mockMapper := &MockFeatureGateMapper{catalogDownstreamKeys: enabledFeatures}
+
+		update := controller.UpdateDeploymentFeatureGatesHook(mockAccessor, mockMapper)
+		err := update(nil, dep)
+		if err != nil {
+			t.Fatalf("unexpected error in first update: %v", err)
+		}
+		if len(dep.Spec.Template.Spec.Containers[0].Args) != 0 {
+			t.Fatalf("args length not 0: %+v", dep)
+		}
+		mockMapper.ValidateCalls(t, 0, 0, 1, 1)
+	})
+
+	t.Run("controller mapping exists with some enabled features and matching container", func(t *testing.T) {
+		dep := testDep.DeepCopy()
+		dep.Name = operatorControllerDeploymentName
+		dep.Spec.Template.Spec.Containers[0].Name = "manager"
+
+		enabledFeatures := []configv1.FeatureGateName{features.FeatureGateNewOLM, features.FeatureGateExample}
+		mockAccessor := &MockFeatureGateAccessor{
+			featureGate: featuregates.NewFeatureGate(
+				enabledFeatures, []configv1.FeatureGateName{},
+			),
+			err: nil,
+		}
+		mockMapper := &MockFeatureGateMapper{
+			ctrlDownstreamKeys: []configv1.FeatureGateName{features.FeatureGateExample},
+			ctrlOut:            []string{"TestUpstreamGate2", "TestUpstreamGate1"},
+		}
+
+		update := controller.UpdateDeploymentFeatureGatesHook(mockAccessor, mockMapper)
+		err := update(nil, dep)
+		if err != nil {
+			t.Fatalf("unexpected error in first update: %v", err)
+		}
+		if len(dep.Spec.Template.Spec.Containers[0].Args) != 1 {
+			t.Fatalf("args length not 1: %+v", dep)
+		}
+		expectedArg := "--feature-gates=TestUpstreamGate1=true,TestUpstreamGate2=true"
+		if expectedArg != dep.Spec.Template.Spec.Containers[0].Args[0] {
+			t.Fatalf("args differ, container: %q, expected: %q", dep.Spec.Template.Spec.Containers[0].Args[0], expectedArg)
+		}
+		mockMapper.ValidateCalls(t, 1, 1, 0, 0)
+
+		err = update(nil, dep)
+		if err == nil {
+			t.Fatal("no error in second update")
+		}
+		// Make sure the Deployment is unchanged
+		if expectedArg != dep.Spec.Template.Spec.Containers[0].Args[0] {
+			t.Fatalf("args differ, container: %q, expected: %q", dep.Spec.Template.Spec.Containers[0].Args[0], expectedArg)
+		}
+		mockMapper.ValidateCalls(t, 2, 2, 0, 0)
+	})
+
+	t.Run("catalog mapping exists with some enabled features and matching container", func(t *testing.T) {
+		dep := testDep.DeepCopy()
+		dep.Name = catalogdDeploymentName
+		dep.Spec.Template.Spec.Containers[0].Name = "manager"
+
+		enabledFeatures := []configv1.FeatureGateName{features.FeatureGateNewOLM, features.FeatureGateExample}
+		mockAccessor := &MockFeatureGateAccessor{
+			featureGate: featuregates.NewFeatureGate(
+				enabledFeatures, []configv1.FeatureGateName{},
+			),
+			err: nil,
+		}
+		mockMapper := &MockFeatureGateMapper{
+			catalogDownstreamKeys: []configv1.FeatureGateName{features.FeatureGateExample},
+			catalogOut:            []string{"TestUpstreamGate2", "TestUpstreamGate1"},
+		}
+
+		update := controller.UpdateDeploymentFeatureGatesHook(mockAccessor, mockMapper)
+		err := update(nil, dep)
+		if err != nil {
+			t.Fatalf("unexpected error in first update: %v", err)
+		}
+		if len(dep.Spec.Template.Spec.Containers[0].Args) != 1 {
+			t.Fatalf("args length not 1: %+v", dep)
+		}
+		expectedArg := "--feature-gates=TestUpstreamGate1=true,TestUpstreamGate2=true"
+		if expectedArg != dep.Spec.Template.Spec.Containers[0].Args[0] {
+			t.Fatalf("args differ, container: %q, expected: %q", dep.Spec.Template.Spec.Containers[0].Args[0], expectedArg)
+		}
+		mockMapper.ValidateCalls(t, 0, 0, 1, 1)
+
+		err = update(nil, dep)
+		if err == nil {
+			t.Fatal("no error in second update")
+		}
+		// Make sure the Deployment is unchanged
+		if expectedArg != dep.Spec.Template.Spec.Containers[0].Args[0] {
+			t.Fatalf("args differ, container: %q, expected: %q", dep.Spec.Template.Spec.Containers[0].Args[0], expectedArg)
+		}
+		mockMapper.ValidateCalls(t, 0, 0, 2, 2)
+	})
+
+	t.Run("controller mapping exists with some features that include duplicates and matching container", func(t *testing.T) {
+		dep := testDep.DeepCopy()
+		dep.Name = operatorControllerDeploymentName
+		dep.Spec.Template.Spec.Containers[0].Name = "manager"
+
+		enabledFeatures := []configv1.FeatureGateName{features.FeatureGateNewOLM, features.FeatureGateExample}
+		mockAccessor := &MockFeatureGateAccessor{
+			featureGate: featuregates.NewFeatureGate(
+				enabledFeatures, []configv1.FeatureGateName{},
+			),
+			err: nil,
+		}
+		mockMapper := &MockFeatureGateMapper{
+			ctrlDownstreamKeys: enabledFeatures,
+			ctrlOut:            []string{"TestUpstreamGate1", "TestUpstreamGate2", "TestUpstreamGate1"},
+		}
+
+		update := controller.UpdateDeploymentFeatureGatesHook(mockAccessor, mockMapper)
+		err := update(nil, dep)
+		if err != nil {
+			t.Fatalf("unexpected error in first update: %v", err)
+		}
+		if len(dep.Spec.Template.Spec.Containers[0].Args) != 1 {
+			t.Fatalf("args length not 1: %+v", dep)
+		}
+		expectedArg := "--feature-gates=TestUpstreamGate1=true,TestUpstreamGate2=true"
+		if expectedArg != dep.Spec.Template.Spec.Containers[0].Args[0] {
+			t.Fatalf("args differ, container: %q, expected: %q", dep.Spec.Template.Spec.Containers[0].Args[0], expectedArg)
+		}
+		mockMapper.ValidateCalls(t, 2, 1, 0, 0)
+
+		err = update(nil, dep)
+		if err == nil {
+			t.Fatal("no error in second update")
+		}
+		// Make sure the Deployment is unchanged
+		if expectedArg != dep.Spec.Template.Spec.Containers[0].Args[0] {
+			t.Fatalf("args differ, container: %q, expected: %q", dep.Spec.Template.Spec.Containers[0].Args[0], expectedArg)
+		}
+		mockMapper.ValidateCalls(t, 4, 2, 0, 0)
+	})
+
+	t.Run("catalog mapping exists with some features that include duplicates and matching container", func(t *testing.T) {
+		dep := testDep.DeepCopy()
+		dep.Name = catalogdDeploymentName
+		dep.Spec.Template.Spec.Containers[0].Name = "manager"
+
+		enabledFeatures := []configv1.FeatureGateName{features.FeatureGateNewOLM, features.FeatureGateExample}
+		mockAccessor := &MockFeatureGateAccessor{
+			featureGate: featuregates.NewFeatureGate(
+				enabledFeatures, []configv1.FeatureGateName{},
+			),
+			err: nil,
+		}
+		mockMapper := &MockFeatureGateMapper{
+			catalogDownstreamKeys: enabledFeatures,
+			catalogOut:            []string{"TestUpstreamGate1", "TestUpstreamGate2", "TestUpstreamGate1"},
+		}
+
+		update := controller.UpdateDeploymentFeatureGatesHook(mockAccessor, mockMapper)
+		err := update(nil, dep)
+		if err != nil {
+			t.Fatalf("unexpected error in first update: %v", err)
+		}
+		if len(dep.Spec.Template.Spec.Containers[0].Args) != 1 {
+			t.Fatalf("args length not 1: %+v", dep)
+		}
+		expectedArg := "--feature-gates=TestUpstreamGate1=true,TestUpstreamGate2=true"
+		if expectedArg != dep.Spec.Template.Spec.Containers[0].Args[0] {
+			t.Fatalf("args differ, container: %q, expected: %q", dep.Spec.Template.Spec.Containers[0].Args[0], expectedArg)
+		}
+		mockMapper.ValidateCalls(t, 0, 0, 2, 1)
+
+		err = update(nil, dep)
+		if err == nil {
+			t.Fatal("no error in second update")
+		}
+		// Make sure the Deployment is unchanged
+		if expectedArg != dep.Spec.Template.Spec.Containers[0].Args[0] {
+			t.Fatalf("args differ, container: %q, expected: %q", dep.Spec.Template.Spec.Containers[0].Args[0], expectedArg)
+		}
+		mockMapper.ValidateCalls(t, 0, 0, 4, 2)
+	})
+}

--- a/vendor/github.com/openshift/api/annotations/annotations.go
+++ b/vendor/github.com/openshift/api/annotations/annotations.go
@@ -1,0 +1,34 @@
+package annotations
+
+// annotation keys
+// NEVER ADD TO THIS LIST.  Annotations need to be owned in the API groups they are associated with, so these constants end
+// up nested in an API group, not top level in the OpenShift namespace.  The items located here are examples of annotations
+// claiming a global namespace key that have never achieved global reach.  In the future, names should be based on the
+// consuming component.
+const (
+	// OpenShiftDisplayName is a common, optional annotation that stores the name displayed by a UI when referencing a resource.
+	OpenShiftDisplayName = "openshift.io/display-name"
+
+	// OpenShiftProviderDisplayNameAnnotation is the name of a provider of a resource, e.g.
+	// "Red Hat, Inc."
+	OpenShiftProviderDisplayNameAnnotation = "openshift.io/provider-display-name"
+
+	// OpenShiftDocumentationURLAnnotation is the url where documentation associated with
+	// a resource can be found.
+	OpenShiftDocumentationURLAnnotation = "openshift.io/documentation-url"
+
+	// OpenShiftSupportURLAnnotation is the url where support for a template can be found.
+	OpenShiftSupportURLAnnotation = "openshift.io/support-url"
+
+	// OpenShiftDescription is a common, optional annotation that stores the description for a resource.
+	OpenShiftDescription = "openshift.io/description"
+
+	// OpenShiftLongDescriptionAnnotation is a resource's long description
+	OpenShiftLongDescriptionAnnotation = "openshift.io/long-description"
+
+	// OpenShiftComponent is a common, optional annotation that stores the owning component for a resource.
+	// The component is for whatever bug tracker we're using.  That used to be bugzilla, now it is
+	// a jira component and subcomponent in OCPBUGS.
+	// For example, "Etcd" or "Networking / ovn-kubernetes"
+	OpenShiftComponent = "openshift.io/owning-component"
+)

--- a/vendor/github.com/openshift/api/features/features.go
+++ b/vendor/github.com/openshift/api/features/features.go
@@ -1,0 +1,689 @@
+package features
+
+import (
+	"fmt"
+
+	configv1 "github.com/openshift/api/config/v1"
+)
+
+func FeatureSets(clusterProfile ClusterProfileName, featureSet configv1.FeatureSet) (*FeatureGateEnabledDisabled, error) {
+	byFeatureSet, ok := allFeatureGates[clusterProfile]
+	if !ok {
+		return nil, fmt.Errorf("no information found for ClusterProfile=%q", clusterProfile)
+	}
+	featureGates, ok := byFeatureSet[featureSet]
+	if !ok {
+		return nil, fmt.Errorf("no information found for FeatureSet=%q under ClusterProfile=%q", featureSet, clusterProfile)
+	}
+	return featureGates.DeepCopy(), nil
+}
+
+func AllFeatureSets() map[ClusterProfileName]map[configv1.FeatureSet]*FeatureGateEnabledDisabled {
+	ret := map[ClusterProfileName]map[configv1.FeatureSet]*FeatureGateEnabledDisabled{}
+
+	for clusterProfile, byFeatureSet := range allFeatureGates {
+		newByFeatureSet := map[configv1.FeatureSet]*FeatureGateEnabledDisabled{}
+
+		for featureSet, enabledDisabled := range byFeatureSet {
+			newByFeatureSet[featureSet] = enabledDisabled.DeepCopy()
+		}
+		ret[clusterProfile] = newByFeatureSet
+	}
+
+	return ret
+}
+
+var (
+	allFeatureGates = map[ClusterProfileName]map[configv1.FeatureSet]*FeatureGateEnabledDisabled{}
+
+	FeatureGateConsolePluginCSP = newFeatureGate("ConsolePluginContentSecurityPolicy").
+					reportProblemsToJiraComponent("Management Console").
+					contactPerson("jhadvig").
+					productScope(ocpSpecific).
+					enableIn(configv1.DevPreviewNoUpgrade, configv1.TechPreviewNoUpgrade).
+					enhancementPR("https://github.com/openshift/enhancements/pull/1706").
+					mustRegister()
+
+	FeatureGateServiceAccountTokenNodeBinding = newFeatureGate("ServiceAccountTokenNodeBinding").
+							reportProblemsToJiraComponent("apiserver-auth").
+							contactPerson("stlaz").
+							productScope(kubernetes).
+							enhancementPR("https://github.com/kubernetes/enhancements/issues/4193").
+							enableIn(configv1.DevPreviewNoUpgrade, configv1.TechPreviewNoUpgrade).
+							mustRegister()
+
+	FeatureGateValidatingAdmissionPolicy = newFeatureGate("ValidatingAdmissionPolicy").
+						reportProblemsToJiraComponent("kube-apiserver").
+						contactPerson("benluddy").
+						productScope(kubernetes).
+						enhancementPR("https://github.com/kubernetes/enhancements/issues/3488").
+						enableIn(configv1.Default, configv1.DevPreviewNoUpgrade, configv1.TechPreviewNoUpgrade).
+						mustRegister()
+
+	FeatureGateGatewayAPI = newFeatureGate("GatewayAPI").
+				reportProblemsToJiraComponent("Routing").
+				contactPerson("miciah").
+				productScope(ocpSpecific).
+				enhancementPR(legacyFeatureGateWithoutEnhancement).
+				enableIn(configv1.DevPreviewNoUpgrade).
+				mustRegister()
+
+	FeatureGateSetEIPForNLBIngressController = newFeatureGate("SetEIPForNLBIngressController").
+							reportProblemsToJiraComponent("Networking / router").
+							contactPerson("miheer").
+							productScope(ocpSpecific).
+							enhancementPR(legacyFeatureGateWithoutEnhancement).
+							enableIn(configv1.Default, configv1.DevPreviewNoUpgrade, configv1.TechPreviewNoUpgrade).
+							mustRegister()
+
+	FeatureGateOpenShiftPodSecurityAdmission = newFeatureGate("OpenShiftPodSecurityAdmission").
+							reportProblemsToJiraComponent("auth").
+							contactPerson("ibihim").
+							productScope(ocpSpecific).
+							enhancementPR("https://github.com/openshift/enhancements/pull/899").
+							enableIn(configv1.Default, configv1.DevPreviewNoUpgrade, configv1.TechPreviewNoUpgrade).
+							mustRegister()
+
+	FeatureGateCSIDriverSharedResource = newFeatureGate("CSIDriverSharedResource").
+						reportProblemsToJiraComponent("builds").
+						contactPerson("adkaplan").
+						productScope(ocpSpecific).
+						enhancementPR("https://github.com/openshift/enhancements/pull/1056").
+						enableIn(configv1.DevPreviewNoUpgrade, configv1.TechPreviewNoUpgrade).
+						mustRegister()
+
+	FeatureGateBuildCSIVolumes = newFeatureGate("BuildCSIVolumes").
+					reportProblemsToJiraComponent("builds").
+					contactPerson("adkaplan").
+					productScope(ocpSpecific).
+					enhancementPR(legacyFeatureGateWithoutEnhancement).
+					enableIn(configv1.Default, configv1.DevPreviewNoUpgrade, configv1.TechPreviewNoUpgrade).
+					mustRegister()
+
+	FeatureGateNodeSwap = newFeatureGate("NodeSwap").
+				reportProblemsToJiraComponent("node").
+				contactPerson("ehashman").
+				productScope(kubernetes).
+				enhancementPR("https://github.com/kubernetes/enhancements/issues/2400").
+				enableIn(configv1.DevPreviewNoUpgrade, configv1.TechPreviewNoUpgrade).
+				mustRegister()
+
+	FeatureGateMachineAPIProviderOpenStack = newFeatureGate("MachineAPIProviderOpenStack").
+						reportProblemsToJiraComponent("openstack").
+						contactPerson("egarcia").
+						productScope(ocpSpecific).
+						enhancementPR(legacyFeatureGateWithoutEnhancement).
+						enableIn(configv1.DevPreviewNoUpgrade, configv1.TechPreviewNoUpgrade).
+						mustRegister()
+
+	FeatureGateInsightsConfigAPI = newFeatureGate("InsightsConfigAPI").
+					reportProblemsToJiraComponent("insights").
+					contactPerson("tremes").
+					productScope(ocpSpecific).
+					enhancementPR(legacyFeatureGateWithoutEnhancement).
+					enableIn(configv1.DevPreviewNoUpgrade, configv1.TechPreviewNoUpgrade).
+					mustRegister()
+
+	FeatureGateInsightsRuntimeExtractor = newFeatureGate("InsightsRuntimeExtractor").
+						reportProblemsToJiraComponent("insights").
+						contactPerson("jmesnil").
+						productScope(ocpSpecific).
+						enhancementPR(legacyFeatureGateWithoutEnhancement).
+						enableIn(configv1.DevPreviewNoUpgrade, configv1.TechPreviewNoUpgrade).
+						mustRegister()
+
+	FeatureGateDynamicResourceAllocation = newFeatureGate("DynamicResourceAllocation").
+						reportProblemsToJiraComponent("scheduling").
+						contactPerson("jchaloup").
+						productScope(kubernetes).
+						enhancementPR("https://github.com/kubernetes/enhancements/issues/4381").
+						enableIn(configv1.DevPreviewNoUpgrade, configv1.TechPreviewNoUpgrade).
+						mustRegister()
+
+	FeatureGateAzureWorkloadIdentity = newFeatureGate("AzureWorkloadIdentity").
+						reportProblemsToJiraComponent("cloud-credential-operator").
+						contactPerson("abutcher").
+						productScope(ocpSpecific).
+						enhancementPR(legacyFeatureGateWithoutEnhancement).
+						enableIn(configv1.Default, configv1.DevPreviewNoUpgrade, configv1.TechPreviewNoUpgrade).
+						mustRegister()
+
+	FeatureGateMaxUnavailableStatefulSet = newFeatureGate("MaxUnavailableStatefulSet").
+						reportProblemsToJiraComponent("apps").
+						contactPerson("atiratree").
+						productScope(kubernetes).
+						enhancementPR("https://github.com/kubernetes/enhancements/issues/961").
+						enableIn(configv1.DevPreviewNoUpgrade, configv1.TechPreviewNoUpgrade).
+						mustRegister()
+
+	FeatureGateEventedPLEG = newFeatureGate("EventedPLEG").
+				reportProblemsToJiraComponent("node").
+				contactPerson("sairameshv").
+				productScope(kubernetes).
+				enhancementPR("https://github.com/kubernetes/enhancements/issues/3386").
+				mustRegister()
+
+	FeatureGatePrivateHostedZoneAWS = newFeatureGate("PrivateHostedZoneAWS").
+					reportProblemsToJiraComponent("Routing").
+					contactPerson("miciah").
+					productScope(ocpSpecific).
+					enhancementPR(legacyFeatureGateWithoutEnhancement).
+					enableIn(configv1.Default, configv1.DevPreviewNoUpgrade, configv1.TechPreviewNoUpgrade).
+					mustRegister()
+
+	FeatureGateSigstoreImageVerification = newFeatureGate("SigstoreImageVerification").
+						reportProblemsToJiraComponent("node").
+						contactPerson("sgrunert").
+						productScope(ocpSpecific).
+						enhancementPR(legacyFeatureGateWithoutEnhancement).
+						enableIn(configv1.DevPreviewNoUpgrade, configv1.TechPreviewNoUpgrade).
+						mustRegister()
+
+	FeatureGateGCPLabelsTags = newFeatureGate("GCPLabelsTags").
+					reportProblemsToJiraComponent("Installer").
+					contactPerson("bhb").
+					productScope(ocpSpecific).
+					enhancementPR(legacyFeatureGateWithoutEnhancement).
+					enableIn(configv1.Default, configv1.DevPreviewNoUpgrade, configv1.TechPreviewNoUpgrade).
+					mustRegister()
+
+	FeatureGateAlibabaPlatform = newFeatureGate("AlibabaPlatform").
+					reportProblemsToJiraComponent("cloud-provider").
+					contactPerson("jspeed").
+					productScope(ocpSpecific).
+					enhancementPR(legacyFeatureGateWithoutEnhancement).
+					enableIn(configv1.Default, configv1.DevPreviewNoUpgrade, configv1.TechPreviewNoUpgrade).
+					mustRegister()
+
+	FeatureGateCloudDualStackNodeIPs = newFeatureGate("CloudDualStackNodeIPs").
+						reportProblemsToJiraComponent("machine-config-operator/platform-baremetal").
+						contactPerson("mkowalsk").
+						productScope(kubernetes).
+						enhancementPR("https://github.com/kubernetes/enhancements/issues/3705").
+						enableIn(configv1.Default, configv1.DevPreviewNoUpgrade, configv1.TechPreviewNoUpgrade).
+						mustRegister()
+
+	FeatureGateVSphereMultiVCenters = newFeatureGate("VSphereMultiVCenters").
+					reportProblemsToJiraComponent("splat").
+					contactPerson("vr4manta").
+					productScope(ocpSpecific).
+					enhancementPR(legacyFeatureGateWithoutEnhancement).
+					enableIn(configv1.DevPreviewNoUpgrade, configv1.TechPreviewNoUpgrade).
+					mustRegister()
+
+	FeatureGateVSphereStaticIPs = newFeatureGate("VSphereStaticIPs").
+					reportProblemsToJiraComponent("splat").
+					contactPerson("rvanderp3").
+					productScope(ocpSpecific).
+					enhancementPR(legacyFeatureGateWithoutEnhancement).
+					enableIn(configv1.Default, configv1.DevPreviewNoUpgrade, configv1.TechPreviewNoUpgrade).
+					mustRegister()
+
+	FeatureGateRouteExternalCertificate = newFeatureGate("RouteExternalCertificate").
+						reportProblemsToJiraComponent("router").
+						contactPerson("thejasn").
+						productScope(ocpSpecific).
+						enhancementPR(legacyFeatureGateWithoutEnhancement).
+						enableIn(configv1.DevPreviewNoUpgrade, configv1.TechPreviewNoUpgrade).
+						mustRegister()
+
+	FeatureGateAdminNetworkPolicy = newFeatureGate("AdminNetworkPolicy").
+					reportProblemsToJiraComponent("Networking/ovn-kubernetes").
+					contactPerson("tssurya").
+					productScope(ocpSpecific).
+					enhancementPR(legacyFeatureGateWithoutEnhancement).
+					enableIn(configv1.Default, configv1.DevPreviewNoUpgrade, configv1.TechPreviewNoUpgrade).
+					mustRegister()
+
+	FeatureGateNetworkSegmentation = newFeatureGate("NetworkSegmentation").
+					reportProblemsToJiraComponent("Networking/ovn-kubernetes").
+					contactPerson("tssurya").
+					productScope(ocpSpecific).
+					enhancementPR(legacyFeatureGateWithoutEnhancement).
+					enableIn(configv1.DevPreviewNoUpgrade, configv1.TechPreviewNoUpgrade).
+					mustRegister()
+
+	FeatureGateAdditionalRoutingCapabilities = newFeatureGate("AdditionalRoutingCapabilities").
+							reportProblemsToJiraComponent("Networking/cluster-network-operator").
+							contactPerson("jcaamano").
+							productScope(ocpSpecific).
+							enhancementPR(legacyFeatureGateWithoutEnhancement).
+							enableIn(configv1.DevPreviewNoUpgrade, configv1.TechPreviewNoUpgrade).
+							mustRegister()
+
+	FeatureGateRouteAdvertisements = newFeatureGate("RouteAdvertisements").
+					reportProblemsToJiraComponent("Networking/ovn-kubernetes").
+					contactPerson("jcaamano").
+					productScope(ocpSpecific).
+					enhancementPR(legacyFeatureGateWithoutEnhancement).
+					enableIn(configv1.DevPreviewNoUpgrade, configv1.TechPreviewNoUpgrade).
+					mustRegister()
+
+	FeatureGateNetworkLiveMigration = newFeatureGate("NetworkLiveMigration").
+					reportProblemsToJiraComponent("Networking/ovn-kubernetes").
+					contactPerson("pliu").
+					productScope(ocpSpecific).
+					enhancementPR(legacyFeatureGateWithoutEnhancement).
+					enableIn(configv1.Default, configv1.DevPreviewNoUpgrade, configv1.TechPreviewNoUpgrade).
+					mustRegister()
+
+	FeatureGateNetworkDiagnosticsConfig = newFeatureGate("NetworkDiagnosticsConfig").
+						reportProblemsToJiraComponent("Networking/cluster-network-operator").
+						contactPerson("kyrtapz").
+						productScope(ocpSpecific).
+						enhancementPR(legacyFeatureGateWithoutEnhancement).
+						enableIn(configv1.Default, configv1.DevPreviewNoUpgrade, configv1.TechPreviewNoUpgrade).
+						mustRegister()
+
+	FeatureGateOVNObservability = newFeatureGate("OVNObservability").
+					reportProblemsToJiraComponent("Networking").
+					contactPerson("npinaeva").
+					productScope(ocpSpecific).
+					enhancementPR(legacyFeatureGateWithoutEnhancement).
+					enableIn(configv1.DevPreviewNoUpgrade, configv1.TechPreviewNoUpgrade).
+					mustRegister()
+
+	FeatureGateHardwareSpeed = newFeatureGate("HardwareSpeed").
+					reportProblemsToJiraComponent("etcd").
+					contactPerson("hasbro17").
+					productScope(ocpSpecific).
+					enhancementPR(legacyFeatureGateWithoutEnhancement).
+					enableIn(configv1.Default, configv1.DevPreviewNoUpgrade, configv1.TechPreviewNoUpgrade).
+					mustRegister()
+
+	FeatureGateBackendQuotaGiB = newFeatureGate("EtcdBackendQuota").
+					reportProblemsToJiraComponent("etcd").
+					contactPerson("hasbro17").
+					productScope(ocpSpecific).
+					enhancementPR(legacyFeatureGateWithoutEnhancement).
+					enableIn(configv1.DevPreviewNoUpgrade, configv1.TechPreviewNoUpgrade).
+					mustRegister()
+
+	FeatureGateAutomatedEtcdBackup = newFeatureGate("AutomatedEtcdBackup").
+					reportProblemsToJiraComponent("etcd").
+					contactPerson("hasbro17").
+					productScope(ocpSpecific).
+					enhancementPR(legacyFeatureGateWithoutEnhancement).
+					enableIn(configv1.DevPreviewNoUpgrade, configv1.TechPreviewNoUpgrade).
+					mustRegister()
+
+	FeatureGateMachineAPIOperatorDisableMachineHealthCheckController = newFeatureGate("MachineAPIOperatorDisableMachineHealthCheckController").
+										reportProblemsToJiraComponent("ecoproject").
+										contactPerson("msluiter").
+										productScope(ocpSpecific).
+										enhancementPR(legacyFeatureGateWithoutEnhancement).
+										mustRegister()
+
+	FeatureGateDNSNameResolver = newFeatureGate("DNSNameResolver").
+					reportProblemsToJiraComponent("dns").
+					contactPerson("miciah").
+					productScope(ocpSpecific).
+					enhancementPR(legacyFeatureGateWithoutEnhancement).
+					enableIn(configv1.DevPreviewNoUpgrade, configv1.TechPreviewNoUpgrade).
+					mustRegister()
+
+	FeatureGateVSphereControlPlaneMachineset = newFeatureGate("VSphereControlPlaneMachineSet").
+							reportProblemsToJiraComponent("splat").
+							contactPerson("rvanderp3").
+							productScope(ocpSpecific).
+							enhancementPR(legacyFeatureGateWithoutEnhancement).
+							enableIn(configv1.Default, configv1.DevPreviewNoUpgrade, configv1.TechPreviewNoUpgrade).
+							mustRegister()
+
+	FeatureGateMachineConfigNodes = newFeatureGate("MachineConfigNodes").
+					reportProblemsToJiraComponent("MachineConfigOperator").
+					contactPerson("cdoern").
+					productScope(ocpSpecific).
+					enhancementPR(legacyFeatureGateWithoutEnhancement).
+					enableIn(configv1.DevPreviewNoUpgrade, configv1.TechPreviewNoUpgrade).
+					mustRegister()
+
+	FeatureGateClusterAPIInstall = newFeatureGate("ClusterAPIInstall").
+					reportProblemsToJiraComponent("Installer").
+					contactPerson("vincepri").
+					productScope(ocpSpecific).
+					enhancementPR(legacyFeatureGateWithoutEnhancement).
+					mustRegister()
+
+	FeatureGateGCPClusterHostedDNS = newFeatureGate("GCPClusterHostedDNS").
+					reportProblemsToJiraComponent("Installer").
+					contactPerson("barbacbd").
+					productScope(ocpSpecific).
+					enhancementPR(legacyFeatureGateWithoutEnhancement).
+					enableIn(configv1.DevPreviewNoUpgrade, configv1.TechPreviewNoUpgrade).
+					mustRegister()
+
+	FeatureGateAWSClusterHostedDNS = newFeatureGate("AWSClusterHostedDNS").
+					reportProblemsToJiraComponent("Installer").
+					contactPerson("barbacbd").
+					productScope(ocpSpecific).
+					enhancementPR(legacyFeatureGateWithoutEnhancement).
+					enableIn(configv1.DevPreviewNoUpgrade, configv1.TechPreviewNoUpgrade).
+					mustRegister()
+
+	FeatureGateMixedCPUsAllocation = newFeatureGate("MixedCPUsAllocation").
+					reportProblemsToJiraComponent("NodeTuningOperator").
+					contactPerson("titzhak").
+					productScope(ocpSpecific).
+					enhancementPR(legacyFeatureGateWithoutEnhancement).
+					enableIn(configv1.DevPreviewNoUpgrade, configv1.TechPreviewNoUpgrade).
+					mustRegister()
+
+	FeatureGateManagedBootImages = newFeatureGate("ManagedBootImages").
+					reportProblemsToJiraComponent("MachineConfigOperator").
+					contactPerson("djoshy").
+					productScope(ocpSpecific).
+					enhancementPR(legacyFeatureGateWithoutEnhancement).
+					enableIn(configv1.Default, configv1.DevPreviewNoUpgrade, configv1.TechPreviewNoUpgrade).
+					mustRegister()
+
+	FeatureGateManagedBootImagesAWS = newFeatureGate("ManagedBootImagesAWS").
+					reportProblemsToJiraComponent("MachineConfigOperator").
+					contactPerson("djoshy").
+					productScope(ocpSpecific).
+					enhancementPR(legacyFeatureGateWithoutEnhancement).
+					enableIn(configv1.Default, configv1.DevPreviewNoUpgrade, configv1.TechPreviewNoUpgrade).
+					mustRegister()
+
+	FeatureGateDisableKubeletCloudCredentialProviders = newFeatureGate("DisableKubeletCloudCredentialProviders").
+								reportProblemsToJiraComponent("cloud-provider").
+								contactPerson("jspeed").
+								productScope(kubernetes).
+								enhancementPR("https://github.com/kubernetes/enhancements/issues/2395").
+								enableIn(configv1.Default, configv1.DevPreviewNoUpgrade, configv1.TechPreviewNoUpgrade).
+								mustRegister()
+
+	FeatureGateOnClusterBuild = newFeatureGate("OnClusterBuild").
+					reportProblemsToJiraComponent("MachineConfigOperator").
+					contactPerson("dkhater").
+					productScope(ocpSpecific).
+					enhancementPR(legacyFeatureGateWithoutEnhancement).
+					enableIn(configv1.DevPreviewNoUpgrade, configv1.TechPreviewNoUpgrade).
+					mustRegister()
+
+	FeatureGateBootcNodeManagement = newFeatureGate("BootcNodeManagement").
+					reportProblemsToJiraComponent("MachineConfigOperator").
+					contactPerson("inesqyx").
+					productScope(ocpSpecific).
+					enhancementPR(legacyFeatureGateWithoutEnhancement).
+					enableIn(configv1.DevPreviewNoUpgrade, configv1.TechPreviewNoUpgrade).
+					mustRegister()
+
+	FeatureGateSignatureStores = newFeatureGate("SignatureStores").
+					reportProblemsToJiraComponent("Cluster Version Operator").
+					contactPerson("lmohanty").
+					productScope(ocpSpecific).
+					enhancementPR(legacyFeatureGateWithoutEnhancement).
+					enableIn(configv1.DevPreviewNoUpgrade, configv1.TechPreviewNoUpgrade).
+					mustRegister()
+
+	FeatureGateKMSv1 = newFeatureGate("KMSv1").
+				reportProblemsToJiraComponent("kube-apiserver").
+				contactPerson("dgrisonnet").
+				productScope(kubernetes).
+				enhancementPR(legacyFeatureGateWithoutEnhancement).
+				enableIn(configv1.Default, configv1.DevPreviewNoUpgrade, configv1.TechPreviewNoUpgrade).
+				mustRegister()
+
+	FeatureGatePinnedImages = newFeatureGate("PinnedImages").
+				reportProblemsToJiraComponent("MachineConfigOperator").
+				contactPerson("jhernand").
+				productScope(ocpSpecific).
+				enhancementPR(legacyFeatureGateWithoutEnhancement).
+				enableIn(configv1.DevPreviewNoUpgrade, configv1.TechPreviewNoUpgrade).
+				mustRegister()
+
+	FeatureGateUpgradeStatus = newFeatureGate("UpgradeStatus").
+					reportProblemsToJiraComponent("Cluster Version Operator").
+					contactPerson("pmuller").
+					productScope(ocpSpecific).
+					enhancementPR(legacyFeatureGateWithoutEnhancement).
+					enableIn(configv1.DevPreviewNoUpgrade, configv1.TechPreviewNoUpgrade).
+					mustRegister()
+
+	FeatureGateTranslateStreamCloseWebsocketRequests = newFeatureGate("TranslateStreamCloseWebsocketRequests").
+								reportProblemsToJiraComponent("kube-apiserver").
+								contactPerson("akashem").
+								productScope(kubernetes).
+								enhancementPR("https://github.com/kubernetes/enhancements/issues/4006").
+								enableIn(configv1.DevPreviewNoUpgrade, configv1.TechPreviewNoUpgrade).
+								mustRegister()
+
+	FeatureGateVolumeAttributesClass = newFeatureGate("VolumeAttributesClass").
+						reportProblemsToJiraComponent("Storage / Kubernetes External Components").
+						contactPerson("dfajmon").
+						productScope(kubernetes).
+						enhancementPR("https://github.com/kubernetes/enhancements/issues/3751").
+						enableIn(configv1.DevPreviewNoUpgrade, configv1.TechPreviewNoUpgrade).
+						mustRegister()
+
+	FeatureGateVolumeGroupSnapshot = newFeatureGate("VolumeGroupSnapshot").
+					reportProblemsToJiraComponent("Storage / Kubernetes External Components").
+					contactPerson("fbertina").
+					productScope(kubernetes).
+					enhancementPR("https://github.com/kubernetes/enhancements/issues/3476").
+					enableIn(configv1.DevPreviewNoUpgrade, configv1.TechPreviewNoUpgrade).
+					mustRegister()
+
+	FeatureGateExternalOIDC = newFeatureGate("ExternalOIDC").
+				reportProblemsToJiraComponent("authentication").
+				contactPerson("liouk").
+				productScope(ocpSpecific).
+				enhancementPR("https://github.com/openshift/enhancements/pull/1596").
+				enableIn(configv1.DevPreviewNoUpgrade, configv1.TechPreviewNoUpgrade).
+				enableForClusterProfile(Hypershift, configv1.Default, configv1.TechPreviewNoUpgrade).
+				mustRegister()
+
+	FeatureGateExample = newFeatureGate("Example").
+				reportProblemsToJiraComponent("cluster-config").
+				contactPerson("deads").
+				productScope(ocpSpecific).
+				enhancementPR(legacyFeatureGateWithoutEnhancement).
+				enableIn(configv1.DevPreviewNoUpgrade, configv1.TechPreviewNoUpgrade).
+				mustRegister()
+
+	FeatureGatePlatformOperators = newFeatureGate("PlatformOperators").
+					reportProblemsToJiraComponent("olm").
+					contactPerson("joe").
+					productScope(ocpSpecific).
+					enhancementPR(legacyFeatureGateWithoutEnhancement).
+					enableIn(configv1.DevPreviewNoUpgrade, configv1.TechPreviewNoUpgrade).
+					mustRegister()
+
+	FeatureGateNewOLM = newFeatureGate("NewOLM").
+				reportProblemsToJiraComponent("olm").
+				contactPerson("joe").
+				productScope(ocpSpecific).
+				enhancementPR(legacyFeatureGateWithoutEnhancement).
+				enableForClusterProfile(SelfManaged, configv1.DevPreviewNoUpgrade, configv1.TechPreviewNoUpgrade, configv1.Default).
+				mustRegister()
+
+	FeatureGateInsightsOnDemandDataGather = newFeatureGate("InsightsOnDemandDataGather").
+						reportProblemsToJiraComponent("insights").
+						contactPerson("tremes").
+						productScope(ocpSpecific).
+						enhancementPR(legacyFeatureGateWithoutEnhancement).
+						enableIn(configv1.DevPreviewNoUpgrade, configv1.TechPreviewNoUpgrade).
+						mustRegister()
+
+	FeatureGateBareMetalLoadBalancer = newFeatureGate("BareMetalLoadBalancer").
+						reportProblemsToJiraComponent("metal").
+						contactPerson("EmilienM").
+						productScope(ocpSpecific).
+						enhancementPR(legacyFeatureGateWithoutEnhancement).
+						enableIn(configv1.Default, configv1.DevPreviewNoUpgrade, configv1.TechPreviewNoUpgrade).
+						mustRegister()
+
+	FeatureGateInsightsConfig = newFeatureGate("InsightsConfig").
+					reportProblemsToJiraComponent("insights").
+					contactPerson("tremes").
+					productScope(ocpSpecific).
+					enhancementPR(legacyFeatureGateWithoutEnhancement).
+					enableIn(configv1.DevPreviewNoUpgrade, configv1.TechPreviewNoUpgrade).
+					mustRegister()
+
+	FeatureGateNodeDisruptionPolicy = newFeatureGate("NodeDisruptionPolicy").
+					reportProblemsToJiraComponent("MachineConfigOperator").
+					contactPerson("jerzhang").
+					productScope(ocpSpecific).
+					enhancementPR(legacyFeatureGateWithoutEnhancement).
+					enableIn(configv1.Default, configv1.DevPreviewNoUpgrade, configv1.TechPreviewNoUpgrade).
+					mustRegister()
+
+	FeatureGateMetricsCollectionProfiles = newFeatureGate("MetricsCollectionProfiles").
+						reportProblemsToJiraComponent("Monitoring").
+						contactPerson("rexagod").
+						productScope(ocpSpecific).
+						enhancementPR(legacyFeatureGateWithoutEnhancement).
+						enableIn(configv1.DevPreviewNoUpgrade, configv1.TechPreviewNoUpgrade).
+						mustRegister()
+
+	FeatureGateVSphereDriverConfiguration = newFeatureGate("VSphereDriverConfiguration").
+						reportProblemsToJiraComponent("Storage / Kubernetes External Components").
+						contactPerson("rbednar").
+						productScope(ocpSpecific).
+						enhancementPR(legacyFeatureGateWithoutEnhancement).
+						enableIn(configv1.Default, configv1.DevPreviewNoUpgrade, configv1.TechPreviewNoUpgrade).
+						mustRegister()
+
+	FeatureGateClusterAPIInstallIBMCloud = newFeatureGate("ClusterAPIInstallIBMCloud").
+						reportProblemsToJiraComponent("Installer").
+						contactPerson("cjschaef").
+						productScope(ocpSpecific).
+						enhancementPR(legacyFeatureGateWithoutEnhancement).
+						mustRegister()
+
+	FeatureGateChunkSizeMiB = newFeatureGate("ChunkSizeMiB").
+				reportProblemsToJiraComponent("Image Registry").
+				contactPerson("flavianmissi").
+				productScope(ocpSpecific).
+				enhancementPR(legacyFeatureGateWithoutEnhancement).
+				enableIn(configv1.Default, configv1.DevPreviewNoUpgrade, configv1.TechPreviewNoUpgrade).
+				mustRegister()
+
+	FeatureGateMachineAPIMigration = newFeatureGate("MachineAPIMigration").
+					reportProblemsToJiraComponent("OCPCLOUD").
+					contactPerson("jspeed").
+					productScope(ocpSpecific).
+					enhancementPR(legacyFeatureGateWithoutEnhancement).
+					mustRegister()
+
+	FeatureGatePersistentIPsForVirtualization = newFeatureGate("PersistentIPsForVirtualization").
+							reportProblemsToJiraComponent("CNV Network").
+							contactPerson("mduarted").
+							productScope(ocpSpecific).
+							enhancementPR(legacyFeatureGateWithoutEnhancement).
+							enableIn(configv1.DevPreviewNoUpgrade, configv1.TechPreviewNoUpgrade).
+							mustRegister()
+
+	FeatureGateClusterMonitoringConfig = newFeatureGate("ClusterMonitoringConfig").
+						reportProblemsToJiraComponent("Monitoring").
+						contactPerson("marioferh").
+						productScope(ocpSpecific).
+						enhancementPR(legacyFeatureGateWithoutEnhancement).
+						enableIn(configv1.DevPreviewNoUpgrade, configv1.TechPreviewNoUpgrade).
+						mustRegister()
+
+	FeatureGateMultiArchInstallAWS = newFeatureGate("MultiArchInstallAWS").
+					reportProblemsToJiraComponent("Installer").
+					contactPerson("r4f4").
+					productScope(ocpSpecific).
+					enhancementPR(legacyFeatureGateWithoutEnhancement).
+					enableIn(configv1.Default, configv1.DevPreviewNoUpgrade, configv1.TechPreviewNoUpgrade).
+					mustRegister()
+
+	FeatureGateMultiArchInstallAzure = newFeatureGate("MultiArchInstallAzure").
+						reportProblemsToJiraComponent("Installer").
+						contactPerson("r4f4").
+						productScope(ocpSpecific).
+						enhancementPR(legacyFeatureGateWithoutEnhancement).
+						mustRegister()
+
+	FeatureGateMultiArchInstallGCP = newFeatureGate("MultiArchInstallGCP").
+					reportProblemsToJiraComponent("Installer").
+					contactPerson("r4f4").
+					productScope(ocpSpecific).
+					enhancementPR(legacyFeatureGateWithoutEnhancement).
+					enableIn(configv1.Default, configv1.DevPreviewNoUpgrade, configv1.TechPreviewNoUpgrade).
+					mustRegister()
+
+	FeatureGateIngressControllerLBSubnetsAWS = newFeatureGate("IngressControllerLBSubnetsAWS").
+							reportProblemsToJiraComponent("Routing").
+							contactPerson("miciah").
+							productScope(ocpSpecific).
+							enhancementPR(legacyFeatureGateWithoutEnhancement).
+							enableIn(configv1.Default, configv1.DevPreviewNoUpgrade, configv1.TechPreviewNoUpgrade).
+							mustRegister()
+
+	FeatureGateAWSEFSDriverVolumeMetrics = newFeatureGate("AWSEFSDriverVolumeMetrics").
+						reportProblemsToJiraComponent("Storage / Kubernetes External Components").
+						contactPerson("fbertina").
+						productScope(ocpSpecific).
+						enhancementPR(legacyFeatureGateWithoutEnhancement).
+						enableIn(configv1.Default, configv1.DevPreviewNoUpgrade, configv1.TechPreviewNoUpgrade).
+						mustRegister()
+
+	FeatureGateImageStreamImportMode = newFeatureGate("ImageStreamImportMode").
+						reportProblemsToJiraComponent("Multi-Arch").
+						contactPerson("psundara").
+						productScope(ocpSpecific).
+						enhancementPR(legacyFeatureGateWithoutEnhancement).
+						enableIn(configv1.DevPreviewNoUpgrade, configv1.TechPreviewNoUpgrade).
+						mustRegister()
+
+	FeatureGateUserNamespacesSupport = newFeatureGate("UserNamespacesSupport").
+						reportProblemsToJiraComponent("Node").
+						contactPerson("haircommander").
+						productScope(kubernetes).
+						enhancementPR("https://github.com/kubernetes/enhancements/issues/127").
+						enableIn(configv1.DevPreviewNoUpgrade, configv1.TechPreviewNoUpgrade).
+						mustRegister()
+
+	FeatureGateUserNamespacesPodSecurityStandards = newFeatureGate("UserNamespacesPodSecurityStandards").
+							reportProblemsToJiraComponent("Node").
+							contactPerson("haircommander").
+							productScope(kubernetes).
+							enhancementPR("https://github.com/kubernetes/enhancements/issues/127").
+							enableIn(configv1.DevPreviewNoUpgrade, configv1.TechPreviewNoUpgrade).
+							mustRegister()
+
+	FeatureGateProcMountType = newFeatureGate("ProcMountType").
+					reportProblemsToJiraComponent("Node").
+					contactPerson("haircommander").
+					productScope(kubernetes).
+					enhancementPR("https://github.com/kubernetes/enhancements/issues/4265").
+					enableIn(configv1.DevPreviewNoUpgrade, configv1.TechPreviewNoUpgrade).
+					mustRegister()
+
+	FeatureGateVSphereMultiNetworks = newFeatureGate("VSphereMultiNetworks").
+					reportProblemsToJiraComponent("SPLAT").
+					contactPerson("rvanderp").
+					productScope(ocpSpecific).
+					enhancementPR(legacyFeatureGateWithoutEnhancement).
+					enableIn(configv1.DevPreviewNoUpgrade, configv1.TechPreviewNoUpgrade).
+					mustRegister()
+
+	FeatureGateIngressControllerDynamicConfigurationManager = newFeatureGate("IngressControllerDynamicConfigurationManager").
+								reportProblemsToJiraComponent("Networking/router").
+								contactPerson("miciah").
+								productScope(ocpSpecific).
+								enhancementPR(legacyFeatureGateWithoutEnhancement).
+								enableIn(configv1.DevPreviewNoUpgrade, configv1.TechPreviewNoUpgrade).
+								mustRegister()
+
+	FeatureGateMinimumKubeletVersion = newFeatureGate("MinimumKubeletVersion").
+						reportProblemsToJiraComponent("Node").
+						contactPerson("haircommander").
+						productScope(ocpSpecific).
+						enableIn(configv1.DevPreviewNoUpgrade, configv1.TechPreviewNoUpgrade).
+						enhancementPR("https://github.com/openshift/enhancements/pull/1697").
+						mustRegister()
+
+	FeatureGateNutanixMultiSubnets = newFeatureGate("NutanixMultiSubnets").
+					reportProblemsToJiraComponent("Cloud Compute / Nutanix Provider").
+					contactPerson("yanhli").
+					productScope(ocpSpecific).
+					enhancementPR("https://github.com/openshift/enhancements/pull/1711").
+					enableIn(configv1.DevPreviewNoUpgrade, configv1.TechPreviewNoUpgrade).
+					mustRegister()
+)

--- a/vendor/github.com/openshift/api/features/legacyfeaturegates.go
+++ b/vendor/github.com/openshift/api/features/legacyfeaturegates.go
@@ -1,0 +1,129 @@
+package features
+
+import "k8s.io/apimachinery/pkg/util/sets"
+
+var legacyFeatureGates = sets.New(
+	"AWSClusterHostedDNS",
+	// never add to this list, if you think you have an exception ask @deads2k
+	"AWSEFSDriverVolumeMetrics",
+	// never add to this list, if you think you have an exception ask @deads2k
+	"AdditionalRoutingCapabilities",
+	// never add to this list, if you think you have an exception ask @deads2k
+	"AdminNetworkPolicy",
+	// never add to this list, if you think you have an exception ask @deads2k
+	"AlibabaPlatform",
+	// never add to this list, if you think you have an exception ask @deads2k
+	"AutomatedEtcdBackup",
+	// never add to this list, if you think you have an exception ask @deads2k
+	"AzureWorkloadIdentity",
+	// never add to this list, if you think you have an exception ask @deads2k
+	"BareMetalLoadBalancer",
+	// never add to this list, if you think you have an exception ask @deads2k
+	"BootcNodeManagement",
+	// never add to this list, if you think you have an exception ask @deads2k
+	"BuildCSIVolumes",
+	// never add to this list, if you think you have an exception ask @deads2k
+	"ChunkSizeMiB",
+	// never add to this list, if you think you have an exception ask @deads2k
+	"ClusterAPIInstall",
+	// never add to this list, if you think you have an exception ask @deads2k
+	"ClusterAPIInstallIBMCloud",
+	// never add to this list, if you think you have an exception ask @deads2k
+	"ClusterMonitoringConfig",
+	// never add to this list, if you think you have an exception ask @deads2k
+	"DNSNameResolver",
+	// never add to this list, if you think you have an exception ask @deads2k
+	"EtcdBackendQuota",
+	// never add to this list, if you think you have an exception ask @deads2k
+	"Example",
+	// never add to this list, if you think you have an exception ask @deads2k
+	"GCPClusterHostedDNS",
+	// never add to this list, if you think you have an exception ask @deads2k
+	"GCPLabelsTags",
+	// never add to this list, if you think you have an exception ask @deads2k
+	"GatewayAPI",
+	// never add to this list, if you think you have an exception ask @deads2k
+	"HardwareSpeed",
+	// never add to this list, if you think you have an exception ask @deads2k
+	"ImageStreamImportMode",
+	// never add to this list, if you think you have an exception ask @deads2k
+	"IngressControllerDynamicConfigurationManager",
+	// never add to this list, if you think you have an exception ask @deads2k
+	"IngressControllerLBSubnetsAWS",
+	// never add to this list, if you think you have an exception ask @deads2k
+	"InsightsConfig",
+	// never add to this list, if you think you have an exception ask @deads2k
+	"InsightsConfigAPI",
+	// never add to this list, if you think you have an exception ask @deads2k
+	"InsightsOnDemandDataGather",
+	// never add to this list, if you think you have an exception ask @deads2k
+	"InsightsRuntimeExtractor",
+	// never add to this list, if you think you have an exception ask @deads2k
+	"KMSv1",
+	// never add to this list, if you think you have an exception ask @deads2k
+	"MachineAPIMigration",
+	// never add to this list, if you think you have an exception ask @deads2k
+	"MachineAPIOperatorDisableMachineHealthCheckController",
+	// never add to this list, if you think you have an exception ask @deads2k
+	"MachineAPIProviderOpenStack",
+	// never add to this list, if you think you have an exception ask @deads2k
+	"MachineConfigNodes",
+	// never add to this list, if you think you have an exception ask @deads2k
+	"ManagedBootImages",
+	// never add to this list, if you think you have an exception ask @deads2k
+	"ManagedBootImagesAWS",
+	// never add to this list, if you think you have an exception ask @deads2k
+	"MetricsCollectionProfiles",
+	// never add to this list, if you think you have an exception ask @deads2k
+	"MixedCPUsAllocation",
+	// never add to this list, if you think you have an exception ask @deads2k
+	"MultiArchInstallAWS",
+	// never add to this list, if you think you have an exception ask @deads2k
+	"MultiArchInstallAzure",
+	// never add to this list, if you think you have an exception ask @deads2k
+	"MultiArchInstallGCP",
+	// never add to this list, if you think you have an exception ask @deads2k
+	"NetworkDiagnosticsConfig",
+	// never add to this list, if you think you have an exception ask @deads2k
+	"NetworkLiveMigration",
+	// never add to this list, if you think you have an exception ask @deads2k
+	"NetworkSegmentation",
+	// never add to this list, if you think you have an exception ask @deads2k
+	"NewOLM",
+	// never add to this list, if you think you have an exception ask @deads2k
+	"NodeDisruptionPolicy",
+	// never add to this list, if you think you have an exception ask @deads2k
+	"OVNObservability",
+	// never add to this list, if you think you have an exception ask @deads2k
+	"OnClusterBuild",
+	// never add to this list, if you think you have an exception ask @deads2k
+	"PersistentIPsForVirtualization",
+	// never add to this list, if you think you have an exception ask @deads2k
+	"PinnedImages",
+	// never add to this list, if you think you have an exception ask @deads2k
+	"PlatformOperators",
+	// never add to this list, if you think you have an exception ask @deads2k
+	"PrivateHostedZoneAWS",
+	// never add to this list, if you think you have an exception ask @deads2k
+	"RouteAdvertisements",
+	// never add to this list, if you think you have an exception ask @deads2k
+	"RouteExternalCertificate",
+	// never add to this list, if you think you have an exception ask @deads2k
+	"SetEIPForNLBIngressController",
+	// never add to this list, if you think you have an exception ask @deads2k
+	"SignatureStores",
+	// never add to this list, if you think you have an exception ask @deads2k
+	"SigstoreImageVerification",
+	// never add to this list, if you think you have an exception ask @deads2k
+	"UpgradeStatus",
+	// never add to this list, if you think you have an exception ask @deads2k
+	"VSphereControlPlaneMachineSet",
+	// never add to this list, if you think you have an exception ask @deads2k
+	"VSphereDriverConfiguration",
+	// never add to this list, if you think you have an exception ask @deads2k
+	"VSphereMultiNetworks",
+	// never add to this list, if you think you have an exception ask @deads2k
+	"VSphereMultiVCenters",
+	// never add to this list, if you think you have an exception ask @deads2k
+	"VSphereStaticIPs",
+)

--- a/vendor/github.com/openshift/api/features/util.go
+++ b/vendor/github.com/openshift/api/features/util.go
@@ -1,0 +1,224 @@
+package features
+
+import (
+	"fmt"
+	configv1 "github.com/openshift/api/config/v1"
+	"net/url"
+	"strings"
+)
+
+// FeatureGateDescription is a golang-only interface used to contains details for a feature gate.
+type FeatureGateDescription struct {
+	// FeatureGateAttributes is the information that appears in the API
+	FeatureGateAttributes configv1.FeatureGateAttributes
+
+	// OwningJiraComponent is the jira component that owns most of the impl and first assignment for the bug.
+	// This is the team that owns the feature long term.
+	OwningJiraComponent string
+	// ResponsiblePerson is the person who is on the hook for first contact.  This is often, but not always, a team lead.
+	// It is someone who can make the promise on the behalf of the team.
+	ResponsiblePerson string
+	// OwningProduct is the product that owns the lifecycle of the gate.
+	OwningProduct OwningProduct
+	// EnhancementPR is the PR for the enhancement.
+	EnhancementPR string
+}
+
+type FeatureGateEnabledDisabled struct {
+	Enabled  []FeatureGateDescription
+	Disabled []FeatureGateDescription
+}
+
+type ClusterProfileName string
+
+var (
+	Hypershift         = ClusterProfileName("include.release.openshift.io/ibm-cloud-managed")
+	SelfManaged        = ClusterProfileName("include.release.openshift.io/self-managed-high-availability")
+	AllClusterProfiles = []ClusterProfileName{Hypershift, SelfManaged}
+)
+
+type OwningProduct string
+
+var (
+	ocpSpecific = OwningProduct("OCP")
+	kubernetes  = OwningProduct("Kubernetes")
+)
+
+type featureGateBuilder struct {
+	name                string
+	owningJiraComponent string
+	responsiblePerson   string
+	owningProduct       OwningProduct
+	enhancementPRURL    string
+
+	statusByClusterProfileByFeatureSet map[ClusterProfileName]map[configv1.FeatureSet]bool
+}
+
+const (
+	legacyFeatureGateWithoutEnhancement = "FeatureGate predates 4.18"
+)
+
+// newFeatureGate featuregate are disabled in every FeatureSet and selectively enabled
+func newFeatureGate(name string) *featureGateBuilder {
+	b := &featureGateBuilder{
+		name:                               name,
+		statusByClusterProfileByFeatureSet: map[ClusterProfileName]map[configv1.FeatureSet]bool{},
+	}
+	for _, clusterProfile := range AllClusterProfiles {
+		byFeatureSet := map[configv1.FeatureSet]bool{}
+		for _, featureSet := range configv1.AllFixedFeatureSets {
+			byFeatureSet[featureSet] = false
+		}
+		b.statusByClusterProfileByFeatureSet[clusterProfile] = byFeatureSet
+	}
+	return b
+}
+
+func (b *featureGateBuilder) reportProblemsToJiraComponent(owningJiraComponent string) *featureGateBuilder {
+	b.owningJiraComponent = owningJiraComponent
+	return b
+}
+
+func (b *featureGateBuilder) contactPerson(responsiblePerson string) *featureGateBuilder {
+	b.responsiblePerson = responsiblePerson
+	return b
+}
+
+func (b *featureGateBuilder) productScope(owningProduct OwningProduct) *featureGateBuilder {
+	b.owningProduct = owningProduct
+	return b
+}
+
+func (b *featureGateBuilder) enhancementPR(url string) *featureGateBuilder {
+	b.enhancementPRURL = url
+	return b
+}
+
+func (b *featureGateBuilder) enableIn(featureSets ...configv1.FeatureSet) *featureGateBuilder {
+	for clusterProfile := range b.statusByClusterProfileByFeatureSet {
+		for _, featureSet := range featureSets {
+			b.statusByClusterProfileByFeatureSet[clusterProfile][featureSet] = true
+		}
+	}
+	return b
+}
+
+func (b *featureGateBuilder) enableForClusterProfile(clusterProfile ClusterProfileName, featureSets ...configv1.FeatureSet) *featureGateBuilder {
+	for _, featureSet := range featureSets {
+		b.statusByClusterProfileByFeatureSet[clusterProfile][featureSet] = true
+	}
+	return b
+}
+
+func (b *featureGateBuilder) register() (configv1.FeatureGateName, error) {
+	if len(b.name) == 0 {
+		return "", fmt.Errorf("missing name")
+	}
+	if len(b.owningJiraComponent) == 0 {
+		return "", fmt.Errorf("missing owningJiraComponent")
+	}
+	if len(b.responsiblePerson) == 0 {
+		return "", fmt.Errorf("missing responsiblePerson")
+	}
+	if len(b.owningProduct) == 0 {
+		return "", fmt.Errorf("missing owningProduct")
+	}
+	_, enhancementPRErr := url.Parse(b.enhancementPRURL)
+	switch {
+	case b.enhancementPRURL == legacyFeatureGateWithoutEnhancement:
+		if !legacyFeatureGates.Has(b.name) {
+			return "", fmt.Errorf("FeatureGate/%s is a new feature gate, not an existing one.  It must have an enhancementPR with GA Graduation Criteria like https://github.com/openshift/enhancements/pull/#### or https://github.com/kubernetes/enhancements/issues/####", b.name)
+		}
+
+	case len(b.enhancementPRURL) == 0:
+		return "", fmt.Errorf("FeatureGate/%s is missing an enhancementPR with GA Graduation Criteria like https://github.com/openshift/enhancements/pull/#### or https://github.com/kubernetes/enhancements/issues/####", b.name)
+
+	case !strings.HasPrefix(b.enhancementPRURL, "https://github.com/openshift/enhancements/pull/") && !strings.HasPrefix(b.enhancementPRURL, "https://github.com/kubernetes/enhancements/issues/"):
+		return "", fmt.Errorf("FeatureGate/%s enhancementPR format is incorrect; must be like https://github.com/openshift/enhancements/pull/#### or https://github.com/kubernetes/enhancements/issues/####", b.name)
+
+	case enhancementPRErr != nil:
+		return "", fmt.Errorf("FeatureGate/%s is enhancementPR is invalid: %w", b.name, enhancementPRErr)
+	}
+
+	featureGateName := configv1.FeatureGateName(b.name)
+	description := FeatureGateDescription{
+		FeatureGateAttributes: configv1.FeatureGateAttributes{
+			Name: featureGateName,
+		},
+		OwningJiraComponent: b.owningJiraComponent,
+		ResponsiblePerson:   b.responsiblePerson,
+		OwningProduct:       b.owningProduct,
+		EnhancementPR:       b.enhancementPRURL,
+	}
+
+	// statusByClusterProfileByFeatureSet is initialized by constructor to be false for every combination
+	for clusterProfile, byFeatureSet := range b.statusByClusterProfileByFeatureSet {
+		for featureSet, enabled := range byFeatureSet {
+			if _, ok := allFeatureGates[clusterProfile]; !ok {
+				allFeatureGates[clusterProfile] = map[configv1.FeatureSet]*FeatureGateEnabledDisabled{}
+			}
+			if _, ok := allFeatureGates[clusterProfile][featureSet]; !ok {
+				allFeatureGates[clusterProfile][featureSet] = &FeatureGateEnabledDisabled{}
+			}
+
+			if enabled {
+				allFeatureGates[clusterProfile][featureSet].Enabled = append(allFeatureGates[clusterProfile][featureSet].Enabled, description)
+			} else {
+				allFeatureGates[clusterProfile][featureSet].Disabled = append(allFeatureGates[clusterProfile][featureSet].Disabled, description)
+			}
+		}
+	}
+
+	return featureGateName, nil
+}
+
+func (b *featureGateBuilder) mustRegister() configv1.FeatureGateName {
+	ret, err := b.register()
+	if err != nil {
+		panic(err)
+	}
+	return ret
+}
+
+// DeepCopyInto is an autogenerated deepcopy function, copying the receiver, writing into out. in must be non-nil.
+func (in *FeatureGateEnabledDisabled) DeepCopyInto(out *FeatureGateEnabledDisabled) {
+	*out = *in
+	if in.Enabled != nil {
+		in, out := &in.Enabled, &out.Enabled
+		*out = make([]FeatureGateDescription, len(*in))
+		copy(*out, *in)
+	}
+	if in.Disabled != nil {
+		in, out := &in.Disabled, &out.Disabled
+		*out = make([]FeatureGateDescription, len(*in))
+		copy(*out, *in)
+	}
+	return
+}
+
+// DeepCopy is an autogenerated deepcopy function, copying the receiver, creating a new FeatureGateEnabledDisabled.
+func (in *FeatureGateEnabledDisabled) DeepCopy() *FeatureGateEnabledDisabled {
+	if in == nil {
+		return nil
+	}
+	out := new(FeatureGateEnabledDisabled)
+	in.DeepCopyInto(out)
+	return out
+}
+
+// DeepCopyInto is an autogenerated deepcopy function, copying the receiver, writing into out. in must be non-nil.
+func (in *FeatureGateDescription) DeepCopyInto(out *FeatureGateDescription) {
+	*out = *in
+	out.FeatureGateAttributes = in.FeatureGateAttributes
+	return
+}
+
+// DeepCopy is an autogenerated deepcopy function, copying the receiver, creating a new FeatureGateDescription.
+func (in *FeatureGateDescription) DeepCopy() *FeatureGateDescription {
+	if in == nil {
+		return nil
+	}
+	out := new(FeatureGateDescription)
+	in.DeepCopyInto(out)
+	return out
+}

--- a/vendor/github.com/openshift/library-go/pkg/certs/pem.go
+++ b/vendor/github.com/openshift/library-go/pkg/certs/pem.go
@@ -1,0 +1,56 @@
+package certs
+
+import (
+	"bytes"
+	"encoding/pem"
+	"os"
+	"path/filepath"
+)
+
+const (
+	// StringSourceEncryptedBlockType is the PEM block type used to store an encrypted string
+	StringSourceEncryptedBlockType = "ENCRYPTED STRING"
+	// StringSourceKeyBlockType is the PEM block type used to store an encrypting key
+	StringSourceKeyBlockType = "ENCRYPTING KEY"
+)
+
+func BlockFromFile(path string, blockType string) (*pem.Block, bool, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil, false, err
+	}
+	block, ok := BlockFromBytes(data, blockType)
+	return block, ok, nil
+}
+
+func BlockFromBytes(data []byte, blockType string) (*pem.Block, bool) {
+	for {
+		block, remaining := pem.Decode(data)
+		if block == nil {
+			return nil, false
+		}
+		if block.Type == blockType {
+			return block, true
+		}
+		data = remaining
+	}
+}
+
+func BlockToFile(path string, block *pem.Block, mode os.FileMode) error {
+	b, err := BlockToBytes(block)
+	if err != nil {
+		return err
+	}
+	if err := os.MkdirAll(filepath.Dir(path), os.FileMode(0755)); err != nil {
+		return err
+	}
+	return os.WriteFile(path, b, mode)
+}
+
+func BlockToBytes(block *pem.Block) ([]byte, error) {
+	b := bytes.Buffer{}
+	if err := pem.Encode(&b, block); err != nil {
+		return nil, err
+	}
+	return b.Bytes(), nil
+}

--- a/vendor/github.com/openshift/library-go/pkg/certs/util.go
+++ b/vendor/github.com/openshift/library-go/pkg/certs/util.go
@@ -1,0 +1,70 @@
+package certs
+
+import (
+	"crypto/x509"
+	"fmt"
+	"strings"
+	"time"
+)
+
+const defaultOutputTimeFormat = "Jan 2 15:04:05 2006"
+
+// nowFn is used in unit test to freeze time.
+var nowFn = time.Now().UTC
+
+// CertificateToString converts a certificate into a human readable string.
+// This function should guarantee consistent output format for must-gather tooling and any code
+// that prints the certificate details.
+func CertificateToString(certificate *x509.Certificate) string {
+	humanName := certificate.Subject.CommonName
+	signerHumanName := certificate.Issuer.CommonName
+
+	if certificate.Subject.CommonName == certificate.Issuer.CommonName {
+		signerHumanName = "<self-signed>"
+	}
+
+	usages := []string{}
+	for _, curr := range certificate.ExtKeyUsage {
+		if curr == x509.ExtKeyUsageClientAuth {
+			usages = append(usages, "client")
+			continue
+		}
+		if curr == x509.ExtKeyUsageServerAuth {
+			usages = append(usages, "serving")
+			continue
+		}
+
+		usages = append(usages, fmt.Sprintf("%d", curr))
+	}
+
+	validServingNames := []string{}
+	for _, ip := range certificate.IPAddresses {
+		validServingNames = append(validServingNames, ip.String())
+	}
+	for _, dnsName := range certificate.DNSNames {
+		validServingNames = append(validServingNames, dnsName)
+	}
+
+	servingString := ""
+	if len(validServingNames) > 0 {
+		servingString = fmt.Sprintf(" validServingFor=[%s]", strings.Join(validServingNames, ","))
+	}
+
+	groupString := ""
+	if len(certificate.Subject.Organization) > 0 {
+		groupString = fmt.Sprintf(" groups=[%s]", strings.Join(certificate.Subject.Organization, ","))
+	}
+
+	return fmt.Sprintf("%q [%s]%s%s issuer=%q (%v to %v (now=%v))", humanName, strings.Join(usages, ","), groupString,
+		servingString, signerHumanName, certificate.NotBefore.UTC().Format(defaultOutputTimeFormat),
+		certificate.NotAfter.UTC().Format(defaultOutputTimeFormat), nowFn().Format(defaultOutputTimeFormat))
+}
+
+// CertificateBundleToString converts a certificate bundle into a human readable string.
+func CertificateBundleToString(bundle []*x509.Certificate) string {
+	output := []string{}
+	for i, cert := range bundle {
+		output = append(output, fmt.Sprintf("[#%d]: %s", i, CertificateToString(cert)))
+	}
+	return strings.Join(output, "\n")
+}

--- a/vendor/github.com/openshift/library-go/pkg/operator/certrotation/OWNERS
+++ b/vendor/github.com/openshift/library-go/pkg/operator/certrotation/OWNERS
@@ -1,0 +1,4 @@
+reviewers:
+  - stlaz
+approvers:
+  - stlaz

--- a/vendor/github.com/openshift/library-go/pkg/operator/certrotation/annotations.go
+++ b/vendor/github.com/openshift/library-go/pkg/operator/certrotation/annotations.go
@@ -1,0 +1,49 @@
+package certrotation
+
+import (
+	"github.com/openshift/api/annotations"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+const (
+	AutoRegenerateAfterOfflineExpiryAnnotation string = "certificates.openshift.io/auto-regenerate-after-offline-expiry"
+)
+
+type AdditionalAnnotations struct {
+	// JiraComponent annotates tls artifacts so that owner could be easily found
+	JiraComponent string
+	// Description is a human-readable one sentence description of certificate purpose
+	Description string
+	// AutoRegenerateAfterOfflineExpiry contains a link to PR and an e2e test name which verifies
+	// that TLS artifact is correctly regenerated after it has expired
+	AutoRegenerateAfterOfflineExpiry string
+}
+
+func (a AdditionalAnnotations) EnsureTLSMetadataUpdate(meta *metav1.ObjectMeta) bool {
+	modified := false
+	if meta.Annotations == nil {
+		meta.Annotations = make(map[string]string)
+	}
+	if len(a.JiraComponent) > 0 && meta.Annotations[annotations.OpenShiftComponent] != a.JiraComponent {
+		meta.Annotations[annotations.OpenShiftComponent] = a.JiraComponent
+		modified = true
+	}
+	if len(a.Description) > 0 && meta.Annotations[annotations.OpenShiftDescription] != a.Description {
+		meta.Annotations[annotations.OpenShiftDescription] = a.Description
+		modified = true
+	}
+	if len(a.AutoRegenerateAfterOfflineExpiry) > 0 && meta.Annotations[AutoRegenerateAfterOfflineExpiryAnnotation] != a.AutoRegenerateAfterOfflineExpiry {
+		meta.Annotations[AutoRegenerateAfterOfflineExpiryAnnotation] = a.AutoRegenerateAfterOfflineExpiry
+		modified = true
+	}
+	return modified
+}
+
+func NewTLSArtifactObjectMeta(name, namespace string, annotations AdditionalAnnotations) metav1.ObjectMeta {
+	meta := metav1.ObjectMeta{
+		Namespace: namespace,
+		Name:      name,
+	}
+	_ = annotations.EnsureTLSMetadataUpdate(&meta)
+	return meta
+}

--- a/vendor/github.com/openshift/library-go/pkg/operator/certrotation/cabundle.go
+++ b/vendor/github.com/openshift/library-go/pkg/operator/certrotation/cabundle.go
@@ -1,0 +1,167 @@
+package certrotation
+
+import (
+	"bytes"
+	"context"
+	"crypto/x509"
+	"fmt"
+	"reflect"
+	"sort"
+
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/equality"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	corev1informers "k8s.io/client-go/informers/core/v1"
+	corev1client "k8s.io/client-go/kubernetes/typed/core/v1"
+	corev1listers "k8s.io/client-go/listers/core/v1"
+	"k8s.io/client-go/util/cert"
+	"k8s.io/klog/v2"
+
+	"github.com/openshift/library-go/pkg/certs"
+	"github.com/openshift/library-go/pkg/crypto"
+	"github.com/openshift/library-go/pkg/operator/events"
+	"github.com/openshift/library-go/pkg/operator/resource/resourcehelper"
+)
+
+// CABundleConfigMap maintains a CA bundle config map, by adding new CA certs coming from RotatedSigningCASecret, and by removing expired old ones.
+type CABundleConfigMap struct {
+	// Namespace is the namespace of the ConfigMap to maintain.
+	Namespace string
+	// Name is the name of the ConfigMap to maintain.
+	Name string
+	// Owner is an optional reference to add to the secret that this rotator creates.
+	Owner *metav1.OwnerReference
+	// AdditionalAnnotations is a collection of annotations set for the secret
+	AdditionalAnnotations AdditionalAnnotations
+	// Plumbing:
+	Informer      corev1informers.ConfigMapInformer
+	Lister        corev1listers.ConfigMapLister
+	Client        corev1client.ConfigMapsGetter
+	EventRecorder events.Recorder
+}
+
+func (c CABundleConfigMap) EnsureConfigMapCABundle(ctx context.Context, signingCertKeyPair *crypto.CA, signingCertKeyPairLocation string) ([]*x509.Certificate, error) {
+	// by this point we have current signing cert/key pair.  We now need to make sure that the ca-bundle configmap has this cert and
+	// doesn't have any expired certs
+	updateRequired := false
+	creationRequired := false
+
+	originalCABundleConfigMap, err := c.Lister.ConfigMaps(c.Namespace).Get(c.Name)
+	if err != nil && !apierrors.IsNotFound(err) {
+		return nil, err
+	}
+	caBundleConfigMap := originalCABundleConfigMap.DeepCopy()
+	if apierrors.IsNotFound(err) {
+		// create an empty one
+		caBundleConfigMap = &corev1.ConfigMap{ObjectMeta: NewTLSArtifactObjectMeta(
+			c.Name,
+			c.Namespace,
+			c.AdditionalAnnotations,
+		)}
+		creationRequired = true
+	}
+
+	needsOwnerUpdate := false
+	if c.Owner != nil {
+		needsOwnerUpdate = ensureOwnerReference(&caBundleConfigMap.ObjectMeta, c.Owner)
+	}
+	needsMetadataUpdate := c.AdditionalAnnotations.EnsureTLSMetadataUpdate(&caBundleConfigMap.ObjectMeta)
+	updateRequired = needsOwnerUpdate || needsMetadataUpdate
+
+	updatedCerts, err := manageCABundleConfigMap(caBundleConfigMap, signingCertKeyPair.Config.Certs[0])
+	if err != nil {
+		return nil, err
+	}
+	if originalCABundleConfigMap == nil || originalCABundleConfigMap.Data == nil || !equality.Semantic.DeepEqual(originalCABundleConfigMap.Data, caBundleConfigMap.Data) {
+		reason := ""
+		if creationRequired {
+			reason = "configmap doesn't exist"
+		} else if originalCABundleConfigMap.Data == nil {
+			reason = "configmap is empty"
+		} else if !equality.Semantic.DeepEqual(originalCABundleConfigMap.Data, caBundleConfigMap.Data) {
+			reason = fmt.Sprintf("signer update %s", signingCertKeyPairLocation)
+		}
+		c.EventRecorder.Eventf("CABundleUpdateRequired", "%q in %q requires a new cert: %s", c.Name, c.Namespace, reason)
+		LabelAsManagedConfigMap(caBundleConfigMap, CertificateTypeCABundle)
+
+		updateRequired = true
+	}
+
+	if creationRequired {
+		actualCABundleConfigMap, err := c.Client.ConfigMaps(c.Namespace).Create(ctx, caBundleConfigMap, metav1.CreateOptions{})
+		resourcehelper.ReportCreateEvent(c.EventRecorder, actualCABundleConfigMap, err)
+		if err != nil {
+			return nil, err
+		}
+		klog.V(2).Infof("Created ca-bundle.crt configmap %s/%s with:\n%s", certs.CertificateBundleToString(updatedCerts), caBundleConfigMap.Namespace, caBundleConfigMap.Name)
+		caBundleConfigMap = actualCABundleConfigMap
+	} else if updateRequired {
+		actualCABundleConfigMap, err := c.Client.ConfigMaps(c.Namespace).Update(ctx, caBundleConfigMap, metav1.UpdateOptions{})
+		resourcehelper.ReportUpdateEvent(c.EventRecorder, actualCABundleConfigMap, err)
+		if err != nil {
+			return nil, err
+		}
+		klog.V(2).Infof("Updated ca-bundle.crt configmap %s/%s with:\n%s", certs.CertificateBundleToString(updatedCerts), caBundleConfigMap.Namespace, caBundleConfigMap.Name)
+		caBundleConfigMap = actualCABundleConfigMap
+	}
+
+	caBundle := caBundleConfigMap.Data["ca-bundle.crt"]
+	if len(caBundle) == 0 {
+		return nil, fmt.Errorf("configmap/%s -n%s missing ca-bundle.crt", caBundleConfigMap.Name, caBundleConfigMap.Namespace)
+	}
+	certificates, err := cert.ParseCertsPEM([]byte(caBundle))
+	if err != nil {
+		return nil, err
+	}
+
+	return certificates, nil
+}
+
+// manageCABundleConfigMap adds the new certificate to the list of cabundles, eliminates duplicates, and prunes the list of expired
+// certs to trust as signers
+func manageCABundleConfigMap(caBundleConfigMap *corev1.ConfigMap, currentSigner *x509.Certificate) ([]*x509.Certificate, error) {
+	if caBundleConfigMap.Data == nil {
+		caBundleConfigMap.Data = map[string]string{}
+	}
+
+	certificates := []*x509.Certificate{}
+	caBundle := caBundleConfigMap.Data["ca-bundle.crt"]
+	if len(caBundle) > 0 {
+		var err error
+		certificates, err = cert.ParseCertsPEM([]byte(caBundle))
+		if err != nil {
+			return nil, err
+		}
+	}
+	certificates = append([]*x509.Certificate{currentSigner}, certificates...)
+	certificates = crypto.FilterExpiredCerts(certificates...)
+
+	finalCertificates := []*x509.Certificate{}
+	// now check for duplicates. n^2, but super simple
+	for i := range certificates {
+		found := false
+		for j := range finalCertificates {
+			if reflect.DeepEqual(certificates[i].Raw, finalCertificates[j].Raw) {
+				found = true
+				break
+			}
+		}
+		if !found {
+			finalCertificates = append(finalCertificates, certificates[i])
+		}
+	}
+
+	// sorting ensures we don't continuously swap the certificates in the bundle, which might cause revision rollouts
+	sort.SliceStable(finalCertificates, func(i, j int) bool {
+		return bytes.Compare(finalCertificates[i].Raw, finalCertificates[j].Raw) < 0
+	})
+	caBytes, err := crypto.EncodeCertificates(finalCertificates...)
+	if err != nil {
+		return nil, err
+	}
+
+	caBundleConfigMap.Data["ca-bundle.crt"] = string(caBytes)
+
+	return finalCertificates, nil
+}

--- a/vendor/github.com/openshift/library-go/pkg/operator/certrotation/client_cert_rotation_controller.go
+++ b/vendor/github.com/openshift/library-go/pkg/operator/certrotation/client_cert_rotation_controller.go
@@ -1,0 +1,169 @@
+package certrotation
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	operatorv1 "github.com/openshift/api/operator/v1"
+	"k8s.io/apimachinery/pkg/util/wait"
+
+	"github.com/openshift/library-go/pkg/controller/factory"
+	"github.com/openshift/library-go/pkg/operator/condition"
+	"github.com/openshift/library-go/pkg/operator/events"
+	"github.com/openshift/library-go/pkg/operator/v1helpers"
+)
+
+const (
+	// CertificateNotBeforeAnnotation contains the certificate expiration date in RFC3339 format.
+	CertificateNotBeforeAnnotation = "auth.openshift.io/certificate-not-before"
+	// CertificateNotAfterAnnotation contains the certificate expiration date in RFC3339 format.
+	CertificateNotAfterAnnotation = "auth.openshift.io/certificate-not-after"
+	// CertificateIssuer contains the common name of the certificate that signed another certificate.
+	CertificateIssuer = "auth.openshift.io/certificate-issuer"
+	// CertificateHostnames contains the hostnames used by a signer.
+	CertificateHostnames = "auth.openshift.io/certificate-hostnames"
+	// RunOnceContextKey is a context value key that can be used to call the controller Sync() and make it only run the syncWorker once and report error.
+	RunOnceContextKey = "cert-rotation-controller.openshift.io/run-once"
+)
+
+// StatusReporter knows how to report the status of cert rotation
+type StatusReporter interface {
+	Report(ctx context.Context, controllerName string, syncErr error) (updated bool, updateErr error)
+}
+
+var _ StatusReporter = (*StaticPodConditionStatusReporter)(nil)
+
+type StaticPodConditionStatusReporter struct {
+	// Plumbing:
+	OperatorClient v1helpers.StaticPodOperatorClient
+}
+
+func (s *StaticPodConditionStatusReporter) Report(ctx context.Context, controllerName string, syncErr error) (bool, error) {
+	newCondition := operatorv1.OperatorCondition{
+		Type:   fmt.Sprintf(condition.CertRotationDegradedConditionTypeFmt, controllerName),
+		Status: operatorv1.ConditionFalse,
+	}
+	if syncErr != nil {
+		newCondition.Status = operatorv1.ConditionTrue
+		newCondition.Reason = "RotationError"
+		newCondition.Message = syncErr.Error()
+	}
+	_, updated, updateErr := v1helpers.UpdateStaticPodStatus(ctx, s.OperatorClient, v1helpers.UpdateStaticPodConditionFn(newCondition))
+	return updated, updateErr
+}
+
+// CertRotationController does:
+//
+// 1) continuously create a self-signed signing CA (via RotatedSigningCASecret) and store it in a secret.
+// 2) maintain a CA bundle ConfigMap with all not yet expired CA certs.
+// 3) continuously create a target cert and key signed by the latest signing CA and store it in a secret.
+type CertRotationController struct {
+	// controller name
+	Name string
+	// RotatedSigningCASecret rotates a self-signed signing CA stored in a secret.
+	RotatedSigningCASecret RotatedSigningCASecret
+	// CABundleConfigMap maintains a CA bundle config map, by adding new CA certs coming from rotatedSigningCASecret, and by removing expired old ones.
+	CABundleConfigMap CABundleConfigMap
+	// RotatedSelfSignedCertKeySecret rotates a key and cert signed by a signing CA and stores it in a secret.
+	RotatedSelfSignedCertKeySecret RotatedSelfSignedCertKeySecret
+
+	// Plumbing:
+	StatusReporter StatusReporter
+}
+
+func NewCertRotationController(
+	name string,
+	rotatedSigningCASecret RotatedSigningCASecret,
+	caBundleConfigMap CABundleConfigMap,
+	rotatedSelfSignedCertKeySecret RotatedSelfSignedCertKeySecret,
+	recorder events.Recorder,
+	reporter StatusReporter,
+) factory.Controller {
+	c := &CertRotationController{
+		Name:                           name,
+		RotatedSigningCASecret:         rotatedSigningCASecret,
+		CABundleConfigMap:              caBundleConfigMap,
+		RotatedSelfSignedCertKeySecret: rotatedSelfSignedCertKeySecret,
+		StatusReporter:                 reporter,
+	}
+	return factory.New().
+		ResyncEvery(time.Minute).
+		WithSync(c.Sync).
+		WithInformers(
+			rotatedSigningCASecret.Informer.Informer(),
+			caBundleConfigMap.Informer.Informer(),
+			rotatedSelfSignedCertKeySecret.Informer.Informer(),
+		).
+		WithPostStartHooks(
+			c.targetCertRecheckerPostRunHook,
+		).
+		ToController(
+			"CertRotationController", // don't change what is passed here unless you also remove the old FooDegraded condition
+			recorder.WithComponentSuffix("cert-rotation-controller").WithComponentSuffix(name),
+		)
+}
+
+func (c CertRotationController) Sync(ctx context.Context, syncCtx factory.SyncContext) error {
+	syncErr := c.SyncWorker(ctx)
+
+	// running this function with RunOnceContextKey value context will make this "run-once" without updating status.
+	isRunOnce, ok := ctx.Value(RunOnceContextKey).(bool)
+	if ok && isRunOnce {
+		return syncErr
+	}
+
+	updated, updateErr := c.StatusReporter.Report(ctx, c.Name, syncErr)
+	if updateErr != nil {
+		return updateErr
+	}
+	if updated && syncErr != nil {
+		syncCtx.Recorder().Warningf("RotationError", syncErr.Error())
+	}
+
+	return syncErr
+}
+
+func (c CertRotationController) getSigningCertKeyPairLocation() string {
+	return fmt.Sprintf("%s/%s", c.RotatedSelfSignedCertKeySecret.Namespace, c.RotatedSelfSignedCertKeySecret.Name)
+}
+
+func (c CertRotationController) SyncWorker(ctx context.Context) error {
+	signingCertKeyPair, _, err := c.RotatedSigningCASecret.EnsureSigningCertKeyPair(ctx)
+	if err != nil {
+		return err
+	}
+
+	cabundleCerts, err := c.CABundleConfigMap.EnsureConfigMapCABundle(ctx, signingCertKeyPair, c.getSigningCertKeyPairLocation())
+	if err != nil {
+		return err
+	}
+
+	if _, err := c.RotatedSelfSignedCertKeySecret.EnsureTargetCertKeyPair(ctx, signingCertKeyPair, cabundleCerts); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (c CertRotationController) targetCertRecheckerPostRunHook(ctx context.Context, syncCtx factory.SyncContext) error {
+	// If we have a need to force rechecking the cert, use this channel to do it.
+	refresher, ok := c.RotatedSelfSignedCertKeySecret.CertCreator.(TargetCertRechecker)
+	if !ok {
+		return nil
+	}
+	targetRefresh := refresher.RecheckChannel()
+	go wait.Until(func() {
+		for {
+			select {
+			case <-targetRefresh:
+				syncCtx.Queue().Add(factory.DefaultQueueKey)
+			case <-ctx.Done():
+				return
+			}
+		}
+	}, time.Minute, ctx.Done())
+
+	<-ctx.Done()
+	return nil
+}

--- a/vendor/github.com/openshift/library-go/pkg/operator/certrotation/config.go
+++ b/vendor/github.com/openshift/library-go/pkg/operator/certrotation/config.go
@@ -1,0 +1,41 @@
+package certrotation
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/wait"
+	"k8s.io/client-go/kubernetes"
+)
+
+// GetCertRotationScale  The normal scale is based on a day.  The value returned by this function
+// is used to scale rotation durations instead of a day, so you can set it shorter.
+func GetCertRotationScale(ctx context.Context, client kubernetes.Interface, namespace string) (time.Duration, error) {
+	certRotationScale := time.Duration(0)
+	err := wait.PollImmediate(time.Second, 1*time.Minute, func() (bool, error) {
+		certRotationConfig, err := client.CoreV1().ConfigMaps(namespace).Get(ctx, "unsupported-cert-rotation-config", metav1.GetOptions{})
+		if err != nil {
+			if errors.IsNotFound(err) {
+				return true, nil
+			}
+			return false, err
+		}
+		if value, ok := certRotationConfig.Data["base"]; ok {
+			certRotationScale, err = time.ParseDuration(value)
+			if err != nil {
+				return false, err
+			}
+		}
+		return true, nil
+	})
+	if err != nil {
+		return 0, err
+	}
+	if certRotationScale > 24*time.Hour {
+		return 0, fmt.Errorf("scale longer than 24h is not allowed: %v", certRotationScale)
+	}
+	return certRotationScale, nil
+}

--- a/vendor/github.com/openshift/library-go/pkg/operator/certrotation/label.go
+++ b/vendor/github.com/openshift/library-go/pkg/operator/certrotation/label.go
@@ -1,0 +1,61 @@
+package certrotation
+
+import (
+	"k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/meta"
+	"k8s.io/apimachinery/pkg/runtime"
+)
+
+const (
+	// ManagedCertificateTypeLabelName marks config map or secret as object that contains managed certificates.
+	// This groups all objects that store certs and allow easy query to get them all.
+	// The value of this label should be set to "true".
+	ManagedCertificateTypeLabelName = "auth.openshift.io/managed-certificate-type"
+)
+
+type CertificateType string
+
+var (
+	CertificateTypeCABundle CertificateType = "ca-bundle"
+	CertificateTypeSigner   CertificateType = "signer"
+	CertificateTypeTarget   CertificateType = "target"
+	CertificateTypeUnknown  CertificateType = "unknown"
+)
+
+// LabelAsManagedConfigMap add label indicating the given config map contains certificates
+// that are managed.
+func LabelAsManagedConfigMap(config *v1.ConfigMap, certificateType CertificateType) {
+	if config.Labels == nil {
+		config.Labels = map[string]string{}
+	}
+	config.Labels[ManagedCertificateTypeLabelName] = string(certificateType)
+}
+
+// LabelAsManagedConfigMap add label indicating the given secret contains certificates
+// that are managed.
+func LabelAsManagedSecret(secret *v1.Secret, certificateType CertificateType) {
+	if secret.Labels == nil {
+		secret.Labels = map[string]string{}
+	}
+	secret.Labels[ManagedCertificateTypeLabelName] = string(certificateType)
+}
+
+// CertificateTypeFromObject returns the CertificateType based on the annotations of the object.
+func CertificateTypeFromObject(obj runtime.Object) (CertificateType, error) {
+	accesor, err := meta.Accessor(obj)
+	if err != nil {
+		return "", err
+	}
+	actualLabels := accesor.GetLabels()
+	if actualLabels == nil {
+		return CertificateTypeUnknown, nil
+	}
+
+	t := CertificateType(actualLabels[ManagedCertificateTypeLabelName])
+	switch t {
+	case CertificateTypeCABundle, CertificateTypeSigner, CertificateTypeTarget:
+		return t, nil
+	default:
+		return CertificateTypeUnknown, nil
+	}
+}

--- a/vendor/github.com/openshift/library-go/pkg/operator/certrotation/metadata.go
+++ b/vendor/github.com/openshift/library-go/pkg/operator/certrotation/metadata.go
@@ -1,0 +1,36 @@
+package certrotation
+
+import (
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func ensureMetadataUpdate(secret *corev1.Secret, owner *metav1.OwnerReference, additionalAnnotations AdditionalAnnotations) bool {
+	needsMetadataUpdate := false
+	// no ownerReference set
+	if owner != nil {
+		needsMetadataUpdate = ensureOwnerReference(&secret.ObjectMeta, owner)
+	}
+	// ownership annotations not set
+	return additionalAnnotations.EnsureTLSMetadataUpdate(&secret.ObjectMeta) || needsMetadataUpdate
+}
+
+func ensureSecretTLSTypeSet(secret *corev1.Secret) bool {
+	// Existing secret not found - no need to update metadata (will be done by needNewSigningCertKeyPair / NeedNewTargetCertKeyPair)
+	if len(secret.ResourceVersion) == 0 {
+		return false
+	}
+
+	// convert outdated secret type (created by pre 4.7 installer)
+	if secret.Type != corev1.SecretTypeTLS {
+		secret.Type = corev1.SecretTypeTLS
+		// wipe secret contents if tls.crt and tls.key are missing
+		_, certExists := secret.Data[corev1.TLSCertKey]
+		_, keyExists := secret.Data[corev1.TLSPrivateKeyKey]
+		if !certExists || !keyExists {
+			secret.Data = map[string][]byte{}
+		}
+		return true
+	}
+	return false
+}

--- a/vendor/github.com/openshift/library-go/pkg/operator/certrotation/signer.go
+++ b/vendor/github.com/openshift/library-go/pkg/operator/certrotation/signer.go
@@ -1,0 +1,223 @@
+package certrotation
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/openshift/library-go/pkg/crypto"
+	"github.com/openshift/library-go/pkg/operator/events"
+	"github.com/openshift/library-go/pkg/operator/resource/resourcehelper"
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	corev1informers "k8s.io/client-go/informers/core/v1"
+	corev1client "k8s.io/client-go/kubernetes/typed/core/v1"
+	corev1listers "k8s.io/client-go/listers/core/v1"
+	"k8s.io/klog/v2"
+)
+
+// RotatedSigningCASecret rotates a self-signed signing CA stored in a secret. It creates a new one when
+// - refresh duration is over
+// - or 80% of validity is over (if RefreshOnlyWhenExpired is false)
+// - or the CA is expired.
+type RotatedSigningCASecret struct {
+	// Namespace is the namespace of the Secret.
+	Namespace string
+	// Name is the name of the Secret.
+	Name string
+	// Validity is the duration from time.Now() until the signing CA expires. If RefreshOnlyWhenExpired
+	// is false, the signing cert is rotated when 80% of validity is reached.
+	Validity time.Duration
+	// Refresh is the duration after signing CA creation when it is rotated at the latest. It is ignored
+	// if RefreshOnlyWhenExpired is true, or if Refresh > Validity.
+	Refresh time.Duration
+	// RefreshOnlyWhenExpired set to true means to ignore 80% of validity and the Refresh duration for rotation,
+	// but only rotate when the signing CA expires. This is useful for auto-recovery when we want to enforce
+	// rotation on expiration only, but not interfere with the ordinary rotation controller.
+	RefreshOnlyWhenExpired bool
+
+	// Owner is an optional reference to add to the secret that this rotator creates. Use this when downstream
+	// consumers of the signer CA need to be aware of changes to the object.
+	// WARNING: be careful when using this option, as deletion of the owning object will cascade into deletion
+	// of the signer. If the lifetime of the owning object is not a superset of the lifetime in which the signer
+	// is used, early deletion will be catastrophic.
+	Owner *metav1.OwnerReference
+
+	// AdditionalAnnotations is a collection of annotations set for the secret
+	AdditionalAnnotations AdditionalAnnotations
+
+	// Plumbing:
+	Informer      corev1informers.SecretInformer
+	Lister        corev1listers.SecretLister
+	Client        corev1client.SecretsGetter
+	EventRecorder events.Recorder
+}
+
+// EnsureSigningCertKeyPair manages the entire lifecycle of a signer cert as a secret, from creation to continued rotation.
+// It always returns the currently used CA pair, a bool indicating whether it was created/updated within this function call and an error.
+func (c RotatedSigningCASecret) EnsureSigningCertKeyPair(ctx context.Context) (*crypto.CA, bool, error) {
+	creationRequired := false
+	updateRequired := false
+	originalSigningCertKeyPairSecret, err := c.Lister.Secrets(c.Namespace).Get(c.Name)
+	if err != nil && !apierrors.IsNotFound(err) {
+		return nil, false, err
+	}
+	signingCertKeyPairSecret := originalSigningCertKeyPairSecret.DeepCopy()
+	if apierrors.IsNotFound(err) {
+		// create an empty one
+		signingCertKeyPairSecret = &corev1.Secret{
+			ObjectMeta: NewTLSArtifactObjectMeta(
+				c.Name,
+				c.Namespace,
+				c.AdditionalAnnotations,
+			),
+			Type: corev1.SecretTypeTLS,
+		}
+		creationRequired = true
+	}
+
+	// run Update if metadata needs changing
+	needsMetadataUpdate := ensureMetadataUpdate(signingCertKeyPairSecret, c.Owner, c.AdditionalAnnotations)
+	needsTypeChange := ensureSecretTLSTypeSet(signingCertKeyPairSecret)
+	updateRequired = needsMetadataUpdate || needsTypeChange
+
+	// run Update if signer content needs changing
+	signerUpdated := false
+	if needed, reason := needNewSigningCertKeyPair(signingCertKeyPairSecret, c.Refresh, c.RefreshOnlyWhenExpired); needed || creationRequired {
+		if creationRequired {
+			reason = "secret doesn't exist"
+		}
+		c.EventRecorder.Eventf("SignerUpdateRequired", "%q in %q requires a new signing cert/key pair: %v", c.Name, c.Namespace, reason)
+		if err := setSigningCertKeyPairSecret(signingCertKeyPairSecret, c.Validity); err != nil {
+			return nil, false, err
+		}
+
+		LabelAsManagedSecret(signingCertKeyPairSecret, CertificateTypeSigner)
+
+		updateRequired = true
+		signerUpdated = true
+	}
+
+	if creationRequired {
+		actualSigningCertKeyPairSecret, err := c.Client.Secrets(c.Namespace).Create(ctx, signingCertKeyPairSecret, metav1.CreateOptions{})
+		resourcehelper.ReportCreateEvent(c.EventRecorder, actualSigningCertKeyPairSecret, err)
+		if err != nil {
+			return nil, false, err
+		}
+		klog.V(2).Infof("Created secret %s/%s", actualSigningCertKeyPairSecret.Namespace, actualSigningCertKeyPairSecret.Name)
+		signingCertKeyPairSecret = actualSigningCertKeyPairSecret
+	} else if updateRequired {
+		actualSigningCertKeyPairSecret, err := c.Client.Secrets(c.Namespace).Update(ctx, signingCertKeyPairSecret, metav1.UpdateOptions{})
+		resourcehelper.ReportUpdateEvent(c.EventRecorder, actualSigningCertKeyPairSecret, err)
+		if err != nil {
+			return nil, false, err
+		}
+		klog.V(2).Infof("Updated secret %s/%s", actualSigningCertKeyPairSecret.Namespace, actualSigningCertKeyPairSecret.Name)
+		signingCertKeyPairSecret = actualSigningCertKeyPairSecret
+	}
+
+	// at this point, the secret has the correct signer, so we should read that signer to be able to sign
+	signingCertKeyPair, err := crypto.GetCAFromBytes(signingCertKeyPairSecret.Data["tls.crt"], signingCertKeyPairSecret.Data["tls.key"])
+	if err != nil {
+		return nil, signerUpdated, err
+	}
+
+	return signingCertKeyPair, signerUpdated, nil
+}
+
+// ensureOwnerReference adds the owner to the list of owner references in meta, if necessary
+func ensureOwnerReference(meta *metav1.ObjectMeta, owner *metav1.OwnerReference) bool {
+	var found bool
+	for _, ref := range meta.OwnerReferences {
+		if ref == *owner {
+			found = true
+			break
+		}
+	}
+	if !found {
+		meta.OwnerReferences = append(meta.OwnerReferences, *owner)
+		return true
+	}
+	return false
+}
+
+func needNewSigningCertKeyPair(secret *corev1.Secret, refresh time.Duration, refreshOnlyWhenExpired bool) (bool, string) {
+	annotations := secret.Annotations
+	notBefore, notAfter, reason := getValidityFromAnnotations(annotations)
+	if len(reason) > 0 {
+		return true, reason
+	}
+
+	if time.Now().After(notAfter) {
+		return true, "already expired"
+	}
+
+	if refreshOnlyWhenExpired {
+		return false, ""
+	}
+
+	validity := notAfter.Sub(notBefore)
+	at80Percent := notAfter.Add(-validity / 5)
+	if time.Now().After(at80Percent) {
+		return true, fmt.Sprintf("past refresh time (80%% of validity): %v", at80Percent)
+	}
+
+	developerSpecifiedRefresh := notBefore.Add(refresh)
+	if time.Now().After(developerSpecifiedRefresh) {
+		return true, fmt.Sprintf("past its refresh time %v", developerSpecifiedRefresh)
+	}
+
+	return false, ""
+}
+
+func getValidityFromAnnotations(annotations map[string]string) (notBefore time.Time, notAfter time.Time, reason string) {
+	notAfterString := annotations[CertificateNotAfterAnnotation]
+	if len(notAfterString) == 0 {
+		return notBefore, notAfter, "missing notAfter"
+	}
+	notAfter, err := time.Parse(time.RFC3339, notAfterString)
+	if err != nil {
+		return notBefore, notAfter, fmt.Sprintf("bad expiry: %q", notAfterString)
+	}
+	notBeforeString := annotations[CertificateNotBeforeAnnotation]
+	if len(notAfterString) == 0 {
+		return notBefore, notAfter, "missing notBefore"
+	}
+	notBefore, err = time.Parse(time.RFC3339, notBeforeString)
+	if err != nil {
+		return notBefore, notAfter, fmt.Sprintf("bad expiry: %q", notBeforeString)
+	}
+
+	return notBefore, notAfter, ""
+}
+
+// setSigningCertKeyPairSecret creates a new signing cert/key pair and sets them in the secret
+func setSigningCertKeyPairSecret(signingCertKeyPairSecret *corev1.Secret, validity time.Duration) error {
+	signerName := fmt.Sprintf("%s_%s@%d", signingCertKeyPairSecret.Namespace, signingCertKeyPairSecret.Name, time.Now().Unix())
+	ca, err := crypto.MakeSelfSignedCAConfigForDuration(signerName, validity)
+	if err != nil {
+		return err
+	}
+
+	certBytes := &bytes.Buffer{}
+	keyBytes := &bytes.Buffer{}
+	if err := ca.WriteCertConfig(certBytes, keyBytes); err != nil {
+		return err
+	}
+
+	if signingCertKeyPairSecret.Annotations == nil {
+		signingCertKeyPairSecret.Annotations = map[string]string{}
+	}
+	if signingCertKeyPairSecret.Data == nil {
+		signingCertKeyPairSecret.Data = map[string][]byte{}
+	}
+	signingCertKeyPairSecret.Data["tls.crt"] = certBytes.Bytes()
+	signingCertKeyPairSecret.Data["tls.key"] = keyBytes.Bytes()
+	signingCertKeyPairSecret.Annotations[CertificateNotAfterAnnotation] = ca.Certs[0].NotAfter.Format(time.RFC3339)
+	signingCertKeyPairSecret.Annotations[CertificateNotBeforeAnnotation] = ca.Certs[0].NotBefore.Format(time.RFC3339)
+	signingCertKeyPairSecret.Annotations[CertificateIssuer] = ca.Certs[0].Issuer.CommonName
+
+	return nil
+}

--- a/vendor/github.com/openshift/library-go/pkg/operator/certrotation/target.go
+++ b/vendor/github.com/openshift/library-go/pkg/operator/certrotation/target.go
@@ -1,0 +1,349 @@
+package certrotation
+
+import (
+	"context"
+	"crypto/x509"
+	"fmt"
+	"strings"
+	"time"
+
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/sets"
+	"k8s.io/apiserver/pkg/authentication/user"
+	"k8s.io/klog/v2"
+
+	"github.com/openshift/library-go/pkg/certs"
+	"github.com/openshift/library-go/pkg/crypto"
+	"github.com/openshift/library-go/pkg/operator/events"
+	"github.com/openshift/library-go/pkg/operator/resource/resourcehelper"
+	corev1informers "k8s.io/client-go/informers/core/v1"
+	corev1client "k8s.io/client-go/kubernetes/typed/core/v1"
+	corev1listers "k8s.io/client-go/listers/core/v1"
+)
+
+// RotatedSelfSignedCertKeySecret rotates a key and cert signed by a signing CA and stores it in a secret.
+//
+// It creates a new one when
+// - refresh duration is over
+// - or 80% of validity is over (if RefreshOnlyWhenExpired is false)
+// - or the cert is expired.
+// - or the signing CA changes.
+type RotatedSelfSignedCertKeySecret struct {
+	// Namespace is the namespace of the Secret.
+	Namespace string
+	// Name is the name of the Secret.
+	Name string
+	// Validity is the duration from time.Now() until the certificate expires. If RefreshOnlyWhenExpired
+	// is false, the key and certificate is rotated when 80% of validity is reached.
+	Validity time.Duration
+	// Refresh is the duration after certificate creation when it is rotated at the latest. It is ignored
+	// if RefreshOnlyWhenExpired is true, or if Refresh > Validity.
+	// Refresh is ignored until the signing CA at least 10% in its life-time to ensure it is deployed
+	// through-out the cluster.
+	Refresh time.Duration
+	// RefreshOnlyWhenExpired allows rotating only certs that are already expired. (for autorecovery)
+	// If false (regular flow) it rotates at the refresh interval but no later then 4/5 of the cert lifetime.
+
+	// RefreshOnlyWhenExpired set to true means to ignore 80% of validity and the Refresh duration for rotation,
+	// but only rotate when the certificate expires. This is useful for auto-recovery when we want to enforce
+	// rotation on expiration only, but not interfere with the ordinary rotation controller.
+	RefreshOnlyWhenExpired bool
+
+	// Owner is an optional reference to add to the secret that this rotator creates. Use this when downstream
+	// consumers of the certificate need to be aware of changes to the object.
+	// WARNING: be careful when using this option, as deletion of the owning object will cascade into deletion
+	// of the certificate. If the lifetime of the owning object is not a superset of the lifetime in which the
+	// certificate is used, early deletion will be catastrophic.
+	Owner *metav1.OwnerReference
+
+	// AdditionalAnnotations is a collection of annotations set for the secret
+	AdditionalAnnotations AdditionalAnnotations
+
+	// CertCreator does the actual cert generation.
+	CertCreator TargetCertCreator
+
+	// Plumbing:
+	Informer      corev1informers.SecretInformer
+	Lister        corev1listers.SecretLister
+	Client        corev1client.SecretsGetter
+	EventRecorder events.Recorder
+}
+
+type TargetCertCreator interface {
+	// NewCertificate creates a new key-cert pair with the given signer.
+	NewCertificate(signer *crypto.CA, validity time.Duration) (*crypto.TLSCertificateConfig, error)
+	// NeedNewTargetCertKeyPair decides whether a new cert-key pair is needed. It returns a non-empty reason if it is the case.
+	NeedNewTargetCertKeyPair(currentCertSecret *corev1.Secret, signer *crypto.CA, caBundleCerts []*x509.Certificate, refresh time.Duration, refreshOnlyWhenExpired, creationRequired bool) string
+	// SetAnnotations gives an option to override or set additional annotations
+	SetAnnotations(cert *crypto.TLSCertificateConfig, annotations map[string]string) map[string]string
+}
+
+// TargetCertRechecker is an optional interface to be implemented by the TargetCertCreator to enforce
+// a controller run.
+type TargetCertRechecker interface {
+	RecheckChannel() <-chan struct{}
+}
+
+func (c RotatedSelfSignedCertKeySecret) EnsureTargetCertKeyPair(ctx context.Context, signingCertKeyPair *crypto.CA, caBundleCerts []*x509.Certificate) (*corev1.Secret, error) {
+	// at this point our trust bundle has been updated.  We don't know for sure that consumers have updated, but that's why we have a second
+	// validity percentage.  We always check to see if we need to sign.  Often we are signing with an old key or we have no target
+	// and need to mint one
+	// TODO do the cross signing thing, but this shows the API consumers want and a very simple impl.
+
+	creationRequired := false
+	updateRequired := false
+	originalTargetCertKeyPairSecret, err := c.Lister.Secrets(c.Namespace).Get(c.Name)
+	if err != nil && !apierrors.IsNotFound(err) {
+		return nil, err
+	}
+	targetCertKeyPairSecret := originalTargetCertKeyPairSecret.DeepCopy()
+	if apierrors.IsNotFound(err) {
+		// create an empty one
+		targetCertKeyPairSecret = &corev1.Secret{
+			ObjectMeta: NewTLSArtifactObjectMeta(
+				c.Name,
+				c.Namespace,
+				c.AdditionalAnnotations,
+			),
+			Type: corev1.SecretTypeTLS,
+		}
+		creationRequired = true
+	}
+
+	needsMetadataUpdate := ensureMetadataUpdate(targetCertKeyPairSecret, c.Owner, c.AdditionalAnnotations)
+	needsTypeChange := ensureSecretTLSTypeSet(targetCertKeyPairSecret)
+	updateRequired = needsMetadataUpdate || needsTypeChange
+
+	if reason := c.CertCreator.NeedNewTargetCertKeyPair(targetCertKeyPairSecret, signingCertKeyPair, caBundleCerts, c.Refresh, c.RefreshOnlyWhenExpired, creationRequired); len(reason) > 0 {
+		c.EventRecorder.Eventf("TargetUpdateRequired", "%q in %q requires a new target cert/key pair: %v", c.Name, c.Namespace, reason)
+		if err := setTargetCertKeyPairSecret(targetCertKeyPairSecret, c.Validity, signingCertKeyPair, c.CertCreator, c.AdditionalAnnotations); err != nil {
+			return nil, err
+		}
+
+		LabelAsManagedSecret(targetCertKeyPairSecret, CertificateTypeTarget)
+
+		updateRequired = true
+	}
+	if creationRequired {
+		actualTargetCertKeyPairSecret, err := c.Client.Secrets(c.Namespace).Create(ctx, targetCertKeyPairSecret, metav1.CreateOptions{})
+		resourcehelper.ReportCreateEvent(c.EventRecorder, actualTargetCertKeyPairSecret, err)
+		if err != nil {
+			return nil, err
+		}
+		klog.V(2).Infof("Created secret %s/%s", actualTargetCertKeyPairSecret.Namespace, actualTargetCertKeyPairSecret.Name)
+		targetCertKeyPairSecret = actualTargetCertKeyPairSecret
+	} else if updateRequired {
+		actualTargetCertKeyPairSecret, err := c.Client.Secrets(c.Namespace).Update(ctx, targetCertKeyPairSecret, metav1.UpdateOptions{})
+		resourcehelper.ReportUpdateEvent(c.EventRecorder, actualTargetCertKeyPairSecret, err)
+		if err != nil {
+			return nil, err
+		}
+		klog.V(2).Infof("Updated secret %s/%s", actualTargetCertKeyPairSecret.Namespace, actualTargetCertKeyPairSecret.Name)
+		targetCertKeyPairSecret = actualTargetCertKeyPairSecret
+	}
+
+	return targetCertKeyPairSecret, nil
+}
+
+func needNewTargetCertKeyPair(secret *corev1.Secret, signer *crypto.CA, caBundleCerts []*x509.Certificate, refresh time.Duration, refreshOnlyWhenExpired, creationRequired bool) string {
+	if creationRequired {
+		return "secret doesn't exist"
+	}
+
+	annotations := secret.Annotations
+	if reason := needNewTargetCertKeyPairForTime(annotations, signer, refresh, refreshOnlyWhenExpired); len(reason) > 0 {
+		return reason
+	}
+
+	// check the signer common name against all the common names in our ca bundle so we don't refresh early
+	signerCommonName := annotations[CertificateIssuer]
+	if len(signerCommonName) == 0 {
+		return "missing issuer name"
+	}
+	for _, caCert := range caBundleCerts {
+		if signerCommonName == caCert.Subject.CommonName {
+			return ""
+		}
+	}
+
+	return fmt.Sprintf("issuer %q, not in ca bundle:\n%s", signerCommonName, certs.CertificateBundleToString(caBundleCerts))
+}
+
+// needNewTargetCertKeyPairForTime returns true when
+//  1. when notAfter or notBefore is missing in the annotation
+//  2. when notAfter or notBefore is malformed
+//  3. when now is after the notAfter
+//  4. when now is after notAfter+refresh AND the signer has been valid
+//     for more than 5% of the "extra" time we renew the target
+//
+// in other words, we rotate if
+//
+// our old CA is gone from the bundle (then we are pretty late to the renewal party)
+// or the cert expired (then we are also pretty late)
+// or we are over the renewal percentage of the validity, but only if the new CA at least 10% into its age.
+// Maybe worth a go doc.
+//
+// So in general we need to see a signing CA at least aged 10% within 1-percentage of the cert validity.
+//
+// Hence, if the CAs are rotated too fast (like CA percentage around 10% or smaller), we will not hit the time to make use of the CA. Or if the cert renewal percentage is at 90%, there is not much time either.
+//
+// So with a cert percentage of 75% and equally long CA and cert validities at the worst case we start at 85% of the cert to renew, trying again every minute.
+func needNewTargetCertKeyPairForTime(annotations map[string]string, signer *crypto.CA, refresh time.Duration, refreshOnlyWhenExpired bool) string {
+	notBefore, notAfter, reason := getValidityFromAnnotations(annotations)
+	if len(reason) > 0 {
+		return reason
+	}
+
+	// Is cert expired?
+	if time.Now().After(notAfter) {
+		return "already expired"
+	}
+
+	if refreshOnlyWhenExpired {
+		return ""
+	}
+
+	// Are we at 80% of validity?
+	validity := notAfter.Sub(notBefore)
+	at80Percent := notAfter.Add(-validity / 5)
+	if time.Now().After(at80Percent) {
+		return fmt.Sprintf("past refresh time (80%% of validity): %v", at80Percent)
+	}
+
+	// If Certificate is past its refresh time, we may have action to take. We only do this if the signer is old enough.
+	refreshTime := notBefore.Add(refresh)
+	if time.Now().After(refreshTime) {
+		// make sure the signer has been valid for more than 10% of the target's refresh time.
+		timeToWaitForTrustRotation := refresh / 10
+		if time.Now().After(signer.Config.Certs[0].NotBefore.Add(time.Duration(timeToWaitForTrustRotation))) {
+			return fmt.Sprintf("past its refresh time %v", refreshTime)
+		}
+	}
+
+	return ""
+}
+
+// setTargetCertKeyPairSecret creates a new cert/key pair and sets them in the secret.  Only one of client, serving, or signer rotation may be specified.
+// TODO refactor with an interface for actually signing and move the one-of check higher in the stack.
+func setTargetCertKeyPairSecret(targetCertKeyPairSecret *corev1.Secret, validity time.Duration, signer *crypto.CA, certCreator TargetCertCreator, annotations AdditionalAnnotations) error {
+	if targetCertKeyPairSecret.Annotations == nil {
+		targetCertKeyPairSecret.Annotations = map[string]string{}
+	}
+	if targetCertKeyPairSecret.Data == nil {
+		targetCertKeyPairSecret.Data = map[string][]byte{}
+	}
+
+	// our annotation is based on our cert validity, so we want to make sure that we don't specify something past our signer
+	targetValidity := validity
+	remainingSignerValidity := signer.Config.Certs[0].NotAfter.Sub(time.Now())
+	if remainingSignerValidity < validity {
+		targetValidity = remainingSignerValidity
+	}
+
+	certKeyPair, err := certCreator.NewCertificate(signer, targetValidity)
+	if err != nil {
+		return err
+	}
+
+	targetCertKeyPairSecret.Data["tls.crt"], targetCertKeyPairSecret.Data["tls.key"], err = certKeyPair.GetPEMBytes()
+	if err != nil {
+		return err
+	}
+	targetCertKeyPairSecret.Annotations[CertificateNotAfterAnnotation] = certKeyPair.Certs[0].NotAfter.Format(time.RFC3339)
+	targetCertKeyPairSecret.Annotations[CertificateNotBeforeAnnotation] = certKeyPair.Certs[0].NotBefore.Format(time.RFC3339)
+	targetCertKeyPairSecret.Annotations[CertificateIssuer] = certKeyPair.Certs[0].Issuer.CommonName
+
+	_ = annotations.EnsureTLSMetadataUpdate(&targetCertKeyPairSecret.ObjectMeta)
+	certCreator.SetAnnotations(certKeyPair, targetCertKeyPairSecret.Annotations)
+
+	return nil
+}
+
+type ClientRotation struct {
+	UserInfo user.Info
+}
+
+func (r *ClientRotation) NewCertificate(signer *crypto.CA, validity time.Duration) (*crypto.TLSCertificateConfig, error) {
+	return signer.MakeClientCertificateForDuration(r.UserInfo, validity)
+}
+
+func (r *ClientRotation) NeedNewTargetCertKeyPair(currentCertSecret *corev1.Secret, signer *crypto.CA, caBundleCerts []*x509.Certificate, refresh time.Duration, refreshOnlyWhenExpired, exists bool) string {
+	return needNewTargetCertKeyPair(currentCertSecret, signer, caBundleCerts, refresh, refreshOnlyWhenExpired, exists)
+}
+
+func (r *ClientRotation) SetAnnotations(cert *crypto.TLSCertificateConfig, annotations map[string]string) map[string]string {
+	return annotations
+}
+
+type ServingRotation struct {
+	Hostnames              ServingHostnameFunc
+	CertificateExtensionFn []crypto.CertificateExtensionFunc
+	HostnamesChanged       <-chan struct{}
+}
+
+func (r *ServingRotation) NewCertificate(signer *crypto.CA, validity time.Duration) (*crypto.TLSCertificateConfig, error) {
+	if len(r.Hostnames()) == 0 {
+		return nil, fmt.Errorf("no hostnames set")
+	}
+	return signer.MakeServerCertForDuration(sets.New(r.Hostnames()...), validity, r.CertificateExtensionFn...)
+}
+
+func (r *ServingRotation) RecheckChannel() <-chan struct{} {
+	return r.HostnamesChanged
+}
+
+func (r *ServingRotation) NeedNewTargetCertKeyPair(currentCertSecret *corev1.Secret, signer *crypto.CA, caBundleCerts []*x509.Certificate, refresh time.Duration, refreshOnlyWhenExpired, creationRequired bool) string {
+	reason := needNewTargetCertKeyPair(currentCertSecret, signer, caBundleCerts, refresh, refreshOnlyWhenExpired, creationRequired)
+	if len(reason) > 0 {
+		return reason
+	}
+
+	return r.missingHostnames(currentCertSecret.Annotations)
+}
+
+func (r *ServingRotation) missingHostnames(annotations map[string]string) string {
+	existingHostnames := sets.New(strings.Split(annotations[CertificateHostnames], ",")...)
+	requiredHostnames := sets.New(r.Hostnames()...)
+	if !existingHostnames.Equal(requiredHostnames) {
+		existingNotRequired := existingHostnames.Difference(requiredHostnames)
+		requiredNotExisting := requiredHostnames.Difference(existingHostnames)
+		return fmt.Sprintf("%q are existing and not required, %q are required and not existing", strings.Join(sets.List(existingNotRequired), ","), strings.Join(sets.List(requiredNotExisting), ","))
+	}
+
+	return ""
+}
+
+func (r *ServingRotation) SetAnnotations(cert *crypto.TLSCertificateConfig, annotations map[string]string) map[string]string {
+	hostnames := sets.Set[string]{}
+	for _, ip := range cert.Certs[0].IPAddresses {
+		hostnames.Insert(ip.String())
+	}
+	for _, dnsName := range cert.Certs[0].DNSNames {
+		hostnames.Insert(dnsName)
+	}
+
+	// List does a sort so that we have a consistent representation
+	annotations[CertificateHostnames] = strings.Join(sets.List(hostnames), ",")
+	return annotations
+}
+
+type ServingHostnameFunc func() []string
+
+type SignerRotation struct {
+	SignerName string
+}
+
+func (r *SignerRotation) NewCertificate(signer *crypto.CA, validity time.Duration) (*crypto.TLSCertificateConfig, error) {
+	signerName := fmt.Sprintf("%s_@%d", r.SignerName, time.Now().Unix())
+	return crypto.MakeCAConfigForDuration(signerName, validity, signer)
+}
+
+func (r *SignerRotation) NeedNewTargetCertKeyPair(currentCertSecret *corev1.Secret, signer *crypto.CA, caBundleCerts []*x509.Certificate, refresh time.Duration, refreshOnlyWhenExpired, exists bool) string {
+	return needNewTargetCertKeyPair(currentCertSecret, signer, caBundleCerts, refresh, refreshOnlyWhenExpired, exists)
+}
+
+func (r *SignerRotation) SetAnnotations(cert *crypto.TLSCertificateConfig, annotations map[string]string) map[string]string {
+	return annotations
+}

--- a/vendor/github.com/openshift/library-go/pkg/operator/condition/condition.go
+++ b/vendor/github.com/openshift/library-go/pkg/operator/condition/condition.go
@@ -1,0 +1,72 @@
+package condition
+
+const (
+	// ManagementStateDegradedConditionType is true when the operator ManagementState is not "Managed"..
+	// Possible reasons are Unmanaged, Removed or Unknown. Any of these cases means the operator is not actively managing the operand.
+	// This condition is set to false when the ManagementState is set to back to "Managed".
+	ManagementStateDegradedConditionType = "ManagementStateDegraded"
+
+	// UnsupportedConfigOverridesUpgradeableConditionType is true when operator unsupported config overrides is changed.
+	// When NoUnsupportedConfigOverrides reason is given it means there are no unsupported config overrides.
+	// When UnsupportedConfigOverridesSet reason is given it means the unsupported config overrides are set, which might impact the ability
+	// of operator to successfully upgrade its operand.
+	UnsupportedConfigOverridesUpgradeableConditionType = "UnsupportedConfigOverridesUpgradeable"
+
+	// MonitoringResourceControllerDegradedConditionType is true when the operator is unable to create or reconcile the ServiceMonitor
+	// CR resource, which is required by monitoring operator to collect Prometheus data from the operator. When this condition is true and the ServiceMonitor
+	// is already created, it won't have impact on collecting metrics. However, if the ServiceMonitor was not created, the metrics won't be available for
+	// collection until this condition is set to false.
+	// The condition is set to false automatically when the operator successfully synchronize the ServiceMonitor resource.
+	MonitoringResourceControllerDegradedConditionType = "MonitoringResourceControllerDegraded"
+
+	// BackingResourceControllerDegradedConditionType is true when the operator is unable to create or reconcile the resources needed
+	// to successfully run the installer pods (installer CRB and SA). If these were already created, this condition is not fatal, however if the resources
+	// were not created it means the installer pod creation will fail.
+	// This condition is set to false when the operator can successfully synchronize installer SA and CRB.
+	BackingResourceControllerDegradedConditionType = "BackingResourceControllerDegraded"
+
+	// StaticPodsDegradedConditionType is true when the operator observe errors when installing the new revision static pods.
+	// This condition report Error reason when the pods are terminated or not ready or waiting during which the operand quality of service is degraded.
+	// This condition is set to False when the pods change state to running and are observed ready.
+	StaticPodsDegradedConditionType = "StaticPodsDegraded"
+
+	// StaticPodsAvailableConditionType is true when the static pod is available on at least one node.
+	StaticPodsAvailableConditionType = "StaticPodsAvailable"
+
+	// ConfigObservationDegradedConditionType is true when the operator failed to observe or process configuration change.
+	// This is not transient condition and normally a correction or manual intervention is required on the config custom resource.
+	ConfigObservationDegradedConditionType = "ConfigObservationDegraded"
+
+	// ResourceSyncControllerDegradedConditionType is true when the operator failed to synchronize one or more secrets or config maps required
+	// to run the operand. Operand ability to provide service might be affected by this condition.
+	// This condition is set to false when the operator is able to create secrets and config maps.
+	ResourceSyncControllerDegradedConditionType = "ResourceSyncControllerDegraded"
+
+	// CertRotationDegradedConditionTypeFmt is true when the operator failed to properly rotate one or more certificates required by the operand.
+	// The RotationError reason is given with message describing details of this failure. This condition can be fatal when ignored as the existing certificate(s)
+	// validity can expire and without rotating/renewing them manual recovery might be required to fix the cluster.
+	CertRotationDegradedConditionTypeFmt = "CertRotation_%s_Degraded"
+
+	// InstallerControllerDegradedConditionType is true when the operator is not able to create new installer pods so the new revisions
+	// cannot be rolled out. This might happen when one or more required secrets or config maps does not exists.
+	// In case the missing secret or config map is available, this condition is automatically set to false.
+	InstallerControllerDegradedConditionType = "InstallerControllerDegraded"
+
+	// NodeInstallerDegradedConditionType is true when the operator is not able to create new installer pods because there are no schedulable nodes
+	// available to run the installer pods.
+	// The AllNodesAtLatestRevision reason is set when all master nodes are updated to the latest revision. It is false when some masters are pending revision.
+	// ZeroNodesActive reason is set to True when no active master nodes are observed. Is set to False when there is at least one active master node.
+	NodeInstallerDegradedConditionType = "NodeInstallerDegraded"
+
+	// NodeInstallerProgressingConditionType is true when the operator is moving nodes to a new revision.
+	NodeInstallerProgressingConditionType = "NodeInstallerProgressing"
+
+	// RevisionControllerDegradedConditionType is true when the operator is not able to create new desired revision because an error occurred when
+	// the operator attempted to created required resource(s) (secrets, configmaps, ...).
+	// This condition mean no new revision will be created.
+	RevisionControllerDegradedConditionType = "RevisionControllerDegraded"
+
+	// NodeControllerDegradedConditionType is true when the operator observed a master node that is not ready.
+	// Note that a node is not ready when its Condition.NodeReady wasn't set to true
+	NodeControllerDegradedConditionType = "NodeControllerDegraded"
+)

--- a/vendor/github.com/openshift/library-go/pkg/operator/configobserver/config_observer_controller.go
+++ b/vendor/github.com/openshift/library-go/pkg/operator/configobserver/config_observer_controller.go
@@ -1,0 +1,301 @@
+package configobserver
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"strings"
+	"time"
+
+	applyoperatorv1 "github.com/openshift/client-go/operator/applyconfigurations/operator/v1"
+
+	"github.com/imdario/mergo"
+	"k8s.io/klog/v2"
+
+	"k8s.io/apimachinery/pkg/api/equality"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/util/diff"
+	"k8s.io/apimachinery/pkg/util/rand"
+	"k8s.io/client-go/tools/cache"
+
+	operatorv1 "github.com/openshift/api/operator/v1"
+
+	"github.com/openshift/library-go/pkg/controller/factory"
+	"github.com/openshift/library-go/pkg/operator/condition"
+	"github.com/openshift/library-go/pkg/operator/events"
+	"github.com/openshift/library-go/pkg/operator/management"
+	"github.com/openshift/library-go/pkg/operator/resourcesynccontroller"
+	"github.com/openshift/library-go/pkg/operator/v1helpers"
+)
+
+// Listers is an interface which will be passed to the config observer funcs.  It is expected to be hard-cast to the "correct" type
+type Listers interface {
+	// ResourceSyncer can be used to copy content from one namespace to another
+	ResourceSyncer() resourcesynccontroller.ResourceSyncer
+	PreRunHasSynced() []cache.InformerSynced
+}
+
+// ObserveConfigFunc observes configuration and returns the observedConfig. This function should not return an
+// observedConfig that would cause the service being managed by the operator to crash. For example, if a required
+// configuration key cannot be observed, consider reusing the configuration key's previous value. Errors that occur
+// while attempting to generate the observedConfig should be returned in the errs slice.
+type ObserveConfigFunc func(listers Listers, recorder events.Recorder, existingConfig map[string]interface{}) (observedConfig map[string]interface{}, errs []error)
+
+type ConfigObserver struct {
+	controllerInstanceName string
+
+	// observers are called in an undefined order and their results are merged to
+	// determine the observed configuration.
+	observers []ObserveConfigFunc
+
+	operatorClient v1helpers.OperatorClient
+
+	// listers are used by config observers to retrieve necessary resources
+	listers Listers
+
+	nestedConfigPath      []string
+	degradedConditionType string
+}
+
+func NewConfigObserver(
+	name string,
+	operatorClient v1helpers.OperatorClient,
+	eventRecorder events.Recorder,
+	listers Listers,
+	informers []factory.Informer,
+	observers ...ObserveConfigFunc,
+) factory.Controller {
+	return NewNestedConfigObserver(
+		name,
+		operatorClient,
+		eventRecorder,
+		listers,
+		informers,
+		nil,
+		"",
+		observers...,
+	)
+}
+
+// NewNestedConfigObserver creates a config observer that watches changes to a nested field (nestedConfigPath) in the config.
+// Useful when the config is shared across multiple controllers in the same process.
+//
+// Example:
+//
+// Given the following configuration, you could run two separate controllers and point each to its own section.
+// The first controller would be responsible for "oauthAPIServer" and the second for "oauthServer" section.
+//
+//	"observedConfig": {
+//	  "oauthAPIServer": {
+//	    "apiServerArguments": {"tls-min-version": "VersionTLS12"}
+//	  },
+//	  "oauthServer": {
+//	    "corsAllowedOrigins": [ "//127\\.0\\.0\\.1(:|$)","//localhost(:|$)"]
+//	  }
+//	}
+//
+// oauthAPIController    := NewNestedConfigObserver(..., []string{"oauthAPIServer"}
+// oauthServerController := NewNestedConfigObserver(..., []string{"oauthServer"}
+func NewNestedConfigObserver(
+	name string,
+	operatorClient v1helpers.OperatorClient,
+	eventRecorder events.Recorder,
+	listers Listers,
+	informers []factory.Informer,
+	nestedConfigPath []string,
+	degradedConditionPrefix string,
+	observers ...ObserveConfigFunc,
+) factory.Controller {
+	c := &ConfigObserver{
+		controllerInstanceName: factory.ControllerInstanceName(name, "ConfigObserver"),
+		operatorClient:         operatorClient,
+		observers:              observers,
+		listers:                listers,
+		nestedConfigPath:       nestedConfigPath,
+		degradedConditionType:  degradedConditionPrefix + condition.ConfigObservationDegradedConditionType,
+	}
+
+	return factory.New().
+		ResyncEvery(time.Minute).
+		WithSync(c.sync).
+		WithInformers(append(informers, listersToInformer(listers)...)...).
+		ToController(
+			"ConfigObserver", // don't change what is passed here unless you also remove the old FooDegraded condition
+			eventRecorder.WithComponentSuffix("config-observer"),
+		)
+}
+
+// sync reacts to a change in prereqs by finding information that is required to match another value in the cluster. This
+// must be information that is logically "owned" by another component.
+func (c ConfigObserver) sync(ctx context.Context, syncCtx factory.SyncContext) error {
+	originalSpec, _, _, err := c.operatorClient.GetOperatorState()
+	if management.IsOperatorRemovable() && apierrors.IsNotFound(err) {
+		return nil
+	}
+	if err != nil {
+		return err
+	}
+	spec := originalSpec.DeepCopy()
+
+	// don't worry about errors.  If we can't decode, we'll simply stomp over the field.
+	existingConfig := map[string]interface{}{}
+	if err := json.NewDecoder(bytes.NewBuffer(spec.ObservedConfig.Raw)).Decode(&existingConfig); err != nil {
+		klog.V(4).Infof("decode of existing config failed with error: %v", err)
+	}
+
+	var errs []error
+	var observedConfigs []map[string]interface{}
+	for _, i := range rand.Perm(len(c.observers)) {
+		var currErrs []error
+		observedConfig, currErrs := c.observers[i](c.listers, syncCtx.Recorder(), existingConfig)
+		observedConfigs = append(observedConfigs, observedConfig)
+		errs = append(errs, currErrs...)
+	}
+
+	mergedObservedConfig := map[string]interface{}{}
+	for _, observedConfig := range observedConfigs {
+		if err := mergo.Merge(&mergedObservedConfig, observedConfig); err != nil {
+			klog.Warningf("merging observed config failed: %v", err)
+		}
+	}
+
+	reverseMergedObservedConfig := map[string]interface{}{}
+	for i := len(observedConfigs) - 1; i >= 0; i-- {
+		if err := mergo.Merge(&reverseMergedObservedConfig, observedConfigs[i]); err != nil {
+			klog.Warningf("merging observed config failed: %v", err)
+		}
+	}
+
+	if !equality.Semantic.DeepEqual(mergedObservedConfig, reverseMergedObservedConfig) {
+		errs = append(errs, errors.New("non-deterministic config observation detected"))
+	}
+
+	if err := c.updateObservedConfig(ctx, syncCtx, existingConfig, mergedObservedConfig); err != nil {
+		errs = []error{err}
+	}
+	configError := v1helpers.NewMultiLineAggregate(errs)
+
+	// update failing condition
+	condition := applyoperatorv1.OperatorCondition().
+		WithType(c.degradedConditionType).
+		WithStatus(operatorv1.ConditionFalse)
+	if configError != nil {
+		condition = condition.
+			WithStatus(operatorv1.ConditionTrue).
+			WithReason("Error").
+			WithMessage(configError.Error())
+	}
+	status := applyoperatorv1.OperatorStatus().WithConditions(condition)
+	updateError := c.operatorClient.ApplyOperatorStatus(ctx, c.controllerInstanceName, status)
+	if updateError != nil {
+		return updateError
+	}
+
+	return configError
+}
+
+func (c ConfigObserver) updateObservedConfig(ctx context.Context, syncCtx factory.SyncContext, existingConfig map[string]interface{}, mergedObservedConfig map[string]interface{}) error {
+	if len(c.nestedConfigPath) == 0 {
+		if !equality.Semantic.DeepEqual(existingConfig, mergedObservedConfig) {
+			syncCtx.Recorder().Eventf("ObservedConfigChanged", "Writing updated observed config: %v", diff.ObjectDiff(existingConfig, mergedObservedConfig))
+			return c.updateConfig(ctx, syncCtx, mergedObservedConfig, v1helpers.UpdateObservedConfigFn)
+		}
+		return nil
+	}
+
+	existingConfigNested, _, err := unstructured.NestedMap(existingConfig, c.nestedConfigPath...)
+	if err != nil {
+		return fmt.Errorf("unable to extract the config under %v key, err %v", c.nestedConfigPath, err)
+	}
+	mergedObservedConfigNested, _, err := unstructured.NestedMap(mergedObservedConfig, c.nestedConfigPath...)
+	if err != nil {
+		return fmt.Errorf("unable to extract the merged config under %v, err %v", c.nestedConfigPath, err)
+	}
+	if !equality.Semantic.DeepEqual(existingConfigNested, mergedObservedConfigNested) {
+		syncCtx.Recorder().Eventf("ObservedConfigChanged", "Writing updated section (%q) of observed config: %q", strings.Join(c.nestedConfigPath, "/"), diff.ObjectDiff(existingConfigNested, mergedObservedConfigNested))
+		return c.updateConfig(ctx, syncCtx, mergedObservedConfigNested, c.updateNestedConfigHelper)
+	}
+	return nil
+}
+
+type updateObservedConfigFn func(config map[string]interface{}) v1helpers.UpdateOperatorSpecFunc
+
+func (c ConfigObserver) updateConfig(ctx context.Context, syncCtx factory.SyncContext, updatedMaybeNestedConfig map[string]interface{}, updateConfigHelper updateObservedConfigFn) error {
+	if _, _, err := v1helpers.UpdateSpec(ctx, c.operatorClient, updateConfigHelper(updatedMaybeNestedConfig)); err != nil {
+		// At this point we failed to write the updated config. If we are permanently broken, do not pile the errors from observers
+		// but instead reset the errors and only report single error condition.
+		syncCtx.Recorder().Warningf("ObservedConfigWriteError", "Failed to write observed config: %v", err)
+		return fmt.Errorf("error writing updated observed config: %v", err)
+	}
+	return nil
+}
+
+// updateNestedConfigHelper returns a helper function for updating the nested config.
+func (c ConfigObserver) updateNestedConfigHelper(updatedNestedConfig map[string]interface{}) v1helpers.UpdateOperatorSpecFunc {
+	return func(currentSpec *operatorv1.OperatorSpec) error {
+		existingConfig := map[string]interface{}{}
+		if err := json.NewDecoder(bytes.NewBuffer(currentSpec.ObservedConfig.Raw)).Decode(&existingConfig); err != nil {
+			klog.V(4).Infof("decode of existing config failed with error: %v", err)
+		}
+		if err := unstructured.SetNestedField(existingConfig, updatedNestedConfig, c.nestedConfigPath...); err != nil {
+			return fmt.Errorf("unable to set the nested (%q) observed config: %v", strings.Join(c.nestedConfigPath, "/"), err)
+		}
+		currentSpec.ObservedConfig = runtime.RawExtension{Object: &unstructured.Unstructured{Object: existingConfig}}
+		return nil
+	}
+}
+
+// listersToInformer converts the Listers interface to informer with empty AddEventHandler as we only care about synced caches in the Run.
+func listersToInformer(l Listers) []factory.Informer {
+	result := make([]factory.Informer, len(l.PreRunHasSynced()))
+	for i := range l.PreRunHasSynced() {
+		result[i] = &listerInformer{cacheSynced: l.PreRunHasSynced()[i]}
+	}
+	return result
+}
+
+type listerInformer struct {
+	cacheSynced cache.InformerSynced
+}
+
+func (l *listerInformer) AddEventHandler(cache.ResourceEventHandler) (cache.ResourceEventHandlerRegistration, error) {
+	return nil, nil
+}
+
+func (l *listerInformer) HasSynced() bool {
+	return l.cacheSynced()
+}
+
+// WithPrefix adds a prefix to the path the input observer would otherwise observe into
+func WithPrefix(observer ObserveConfigFunc, prefix ...string) ObserveConfigFunc {
+	if len(prefix) == 0 {
+		return observer
+	}
+
+	return func(listers Listers, recorder events.Recorder, existingConfig map[string]interface{}) (map[string]interface{}, []error) {
+		errs := []error{}
+
+		nestedExistingConfig, _, err := unstructured.NestedMap(existingConfig, prefix...)
+		if err != nil {
+			errs = append(errs, err)
+		}
+
+		orig, observerErrs := observer(listers, recorder, nestedExistingConfig)
+		errs = append(errs, observerErrs...)
+
+		if orig == nil {
+			return nil, errs
+		}
+
+		ret := map[string]interface{}{}
+		if err := unstructured.SetNestedField(ret, orig, prefix...); err != nil {
+			errs = append(errs, err)
+		}
+		return ret, errs
+
+	}
+}

--- a/vendor/github.com/openshift/library-go/pkg/operator/configobserver/featuregates/featuregate.go
+++ b/vendor/github.com/openshift/library-go/pkg/operator/configobserver/featuregates/featuregate.go
@@ -1,0 +1,48 @@
+package featuregates
+
+import (
+	"fmt"
+	"slices"
+
+	configv1 "github.com/openshift/api/config/v1"
+)
+
+// FeatureGate indicates whether a given feature is enabled or not
+// This interface is heavily influenced by k8s.io/component-base, but not exactly compatible.
+type FeatureGate interface {
+	// Enabled returns true if the key is enabled.
+	Enabled(key configv1.FeatureGateName) bool
+	// KnownFeatures returns a slice of strings describing the FeatureGate's known features.
+	KnownFeatures() []configv1.FeatureGateName
+}
+
+type featureGate struct {
+	enabled  []configv1.FeatureGateName
+	disabled []configv1.FeatureGateName
+}
+
+func NewFeatureGate(enabled, disabled []configv1.FeatureGateName) FeatureGate {
+	return &featureGate{
+		enabled:  enabled,
+		disabled: disabled,
+	}
+}
+
+func (f *featureGate) Enabled(key configv1.FeatureGateName) bool {
+	if slices.Contains(f.enabled, key) {
+		return true
+	}
+	if slices.Contains(f.disabled, key) {
+		return false
+	}
+
+	panic(fmt.Errorf("feature %q is not registered in FeatureGates %v", key, f.KnownFeatures()))
+}
+
+func (f *featureGate) KnownFeatures() []configv1.FeatureGateName {
+	allKnown := make([]configv1.FeatureGateName, 0, len(f.enabled)+len(f.disabled))
+	allKnown = append(allKnown, f.enabled...)
+	allKnown = append(allKnown, f.disabled...)
+
+	return allKnown
+}

--- a/vendor/github.com/openshift/library-go/pkg/operator/configobserver/featuregates/hardcoded_featuregate_reader.go
+++ b/vendor/github.com/openshift/library-go/pkg/operator/configobserver/featuregates/hardcoded_featuregate_reader.go
@@ -1,0 +1,78 @@
+package featuregates
+
+import (
+	"context"
+	"fmt"
+
+	configv1 "github.com/openshift/api/config/v1"
+)
+
+type hardcodedFeatureGateAccess struct {
+	enabled  []configv1.FeatureGateName
+	disabled []configv1.FeatureGateName
+	readErr  error
+
+	initialFeatureGatesObserved chan struct{}
+}
+
+// NewHardcodedFeatureGateAccess returns a FeatureGateAccess that is always initialized and always
+// returns the provided feature gates.
+func NewHardcodedFeatureGateAccess(enabled, disabled []configv1.FeatureGateName) FeatureGateAccess {
+	initialFeatureGatesObserved := make(chan struct{})
+	close(initialFeatureGatesObserved)
+	c := &hardcodedFeatureGateAccess{
+		enabled:                     enabled,
+		disabled:                    disabled,
+		initialFeatureGatesObserved: initialFeatureGatesObserved,
+	}
+
+	return c
+}
+
+// NewHardcodedFeatureGateAccessForTesting returns a FeatureGateAccess that returns stub responses
+// using caller-supplied values.
+func NewHardcodedFeatureGateAccessForTesting(enabled, disabled []configv1.FeatureGateName, initialFeatureGatesObserved chan struct{}, readErr error) FeatureGateAccess {
+	return &hardcodedFeatureGateAccess{
+		enabled:                     enabled,
+		disabled:                    disabled,
+		initialFeatureGatesObserved: initialFeatureGatesObserved,
+		readErr:                     readErr,
+	}
+}
+
+func (c *hardcodedFeatureGateAccess) SetChangeHandler(featureGateChangeHandlerFn FeatureGateChangeHandlerFunc) {
+	// ignore
+}
+
+func (c *hardcodedFeatureGateAccess) Run(ctx context.Context) {
+	// ignore
+}
+
+func (c *hardcodedFeatureGateAccess) InitialFeatureGatesObserved() <-chan struct{} {
+	return c.initialFeatureGatesObserved
+}
+
+func (c *hardcodedFeatureGateAccess) AreInitialFeatureGatesObserved() bool {
+	select {
+	case <-c.InitialFeatureGatesObserved():
+		return true
+	default:
+		return false
+	}
+}
+
+func (c *hardcodedFeatureGateAccess) CurrentFeatureGates() (FeatureGate, error) {
+	return NewFeatureGate(c.enabled, c.disabled), c.readErr
+}
+
+// NewHardcodedFeatureGateAccessFromFeatureGate returns a FeatureGateAccess that is static and initialised from
+// a populated FeatureGate status.
+// If the desired version is missing, this will return an error.
+func NewHardcodedFeatureGateAccessFromFeatureGate(featureGate *configv1.FeatureGate, desiredVersion string) (FeatureGateAccess, error) {
+	features, err := featuresFromFeatureGate(featureGate, desiredVersion)
+	if err != nil {
+		return nil, fmt.Errorf("unable to determine features: %w", err)
+	}
+
+	return NewHardcodedFeatureGateAccess(features.Enabled, features.Disabled), nil
+}

--- a/vendor/github.com/openshift/library-go/pkg/operator/configobserver/featuregates/observe_featuregates.go
+++ b/vendor/github.com/openshift/library-go/pkg/operator/configobserver/featuregates/observe_featuregates.go
@@ -1,0 +1,118 @@
+package featuregates
+
+import (
+	"fmt"
+	"reflect"
+	"strings"
+
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/util/sets"
+
+	configv1 "github.com/openshift/api/config/v1"
+	"github.com/openshift/library-go/pkg/operator/configobserver"
+	"github.com/openshift/library-go/pkg/operator/events"
+)
+
+// NewObserveFeatureFlagsFunc produces a configobserver for feature gates.  If non-nil, the featureWhitelist filters
+// feature gates to a known subset (instead of everything).  The featureBlacklist will stop certain features from making
+// it through the list.  The featureBlacklist should be empty, but for a brief time, some featuregates may need to skipped.
+// @smarterclayton will live forever in shame for being the first to require this for "IPv6DualStack".
+func NewObserveFeatureFlagsFunc(featureWhitelist sets.Set[configv1.FeatureGateName], featureBlacklist sets.Set[configv1.FeatureGateName], configPath []string, featureGateAccess FeatureGateAccess) configobserver.ObserveConfigFunc {
+	return (&featureFlags{
+		allowAll:          len(featureWhitelist) == 0,
+		featureWhitelist:  featureWhitelist,
+		featureBlacklist:  featureBlacklist,
+		configPath:        configPath,
+		featureGateAccess: featureGateAccess,
+	}).ObserveFeatureFlags
+}
+
+type featureFlags struct {
+	allowAll         bool
+	featureWhitelist sets.Set[configv1.FeatureGateName]
+	// we add a forceDisableFeature list because we've now had bad featuregates break individual operators.  Awesome.
+	featureBlacklist  sets.Set[configv1.FeatureGateName]
+	configPath        []string
+	featureGateAccess FeatureGateAccess
+}
+
+// ObserveFeatureFlags fills in --feature-flags for the kube-apiserver
+func (f *featureFlags) ObserveFeatureFlags(genericListers configobserver.Listers, recorder events.Recorder, existingConfig map[string]interface{}) (map[string]interface{}, []error) {
+	prunedExistingConfig := configobserver.Pruned(existingConfig, f.configPath)
+
+	errs := []error{}
+
+	if !f.featureGateAccess.AreInitialFeatureGatesObserved() {
+		// if we haven't observed featuregates yet, return the existing
+		return prunedExistingConfig, nil
+	}
+
+	featureGates, err := f.featureGateAccess.CurrentFeatureGates()
+	if err != nil {
+		return prunedExistingConfig, append(errs, err)
+	}
+	observedConfig := map[string]interface{}{}
+	newConfigValue := f.getWhitelistedFeatureNames(featureGates)
+
+	currentConfigValue, _, err := unstructured.NestedStringSlice(existingConfig, f.configPath...)
+	if err != nil {
+		errs = append(errs, err)
+		// keep going on read error from existing config
+	}
+	if !reflect.DeepEqual(currentConfigValue, newConfigValue) {
+		recorder.Eventf("ObserveFeatureFlagsUpdated", "Updated %v to %s", strings.Join(f.configPath, "."), strings.Join(newConfigValue, ","))
+	}
+
+	if err := unstructured.SetNestedStringSlice(observedConfig, newConfigValue, f.configPath...); err != nil {
+		recorder.Warningf("ObserveFeatureFlags", "Failed setting %v: %v", strings.Join(f.configPath, "."), err)
+		return prunedExistingConfig, append(errs, err)
+	}
+
+	return configobserver.Pruned(observedConfig, f.configPath), errs
+}
+
+func (f *featureFlags) getWhitelistedFeatureNames(featureGates FeatureGate) []string {
+	newConfigValue := []string{}
+	formatEnabledFunc := func(fs configv1.FeatureGateName) string {
+		return fmt.Sprintf("%v=true", fs)
+	}
+	formatDisabledFunc := func(fs configv1.FeatureGateName) string {
+		return fmt.Sprintf("%v=false", fs)
+	}
+
+	for _, knownFeatureGate := range featureGates.KnownFeatures() {
+		if f.featureBlacklist.Has(knownFeatureGate) {
+			continue
+		}
+		// only add whitelisted feature flags
+		if !f.allowAll && !f.featureWhitelist.Has(knownFeatureGate) {
+			continue
+		}
+
+		if featureGates.Enabled(knownFeatureGate) {
+			newConfigValue = append(newConfigValue, formatEnabledFunc(knownFeatureGate))
+		} else {
+			newConfigValue = append(newConfigValue, formatDisabledFunc(knownFeatureGate))
+		}
+	}
+
+	return newConfigValue
+}
+
+func StringsToFeatureGateNames(in []string) []configv1.FeatureGateName {
+	out := []configv1.FeatureGateName{}
+	for _, curr := range in {
+		out = append(out, configv1.FeatureGateName(curr))
+	}
+
+	return out
+}
+
+func FeatureGateNamesToStrings(in []configv1.FeatureGateName) []string {
+	out := []string{}
+	for _, curr := range in {
+		out = append(out, string(curr))
+	}
+
+	return out
+}

--- a/vendor/github.com/openshift/library-go/pkg/operator/configobserver/featuregates/simple_featuregate_reader.go
+++ b/vendor/github.com/openshift/library-go/pkg/operator/configobserver/featuregates/simple_featuregate_reader.go
@@ -1,0 +1,318 @@
+package featuregates
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"reflect"
+	"sync"
+	"time"
+
+	configv1 "github.com/openshift/api/config/v1"
+
+	v1 "github.com/openshift/client-go/config/informers/externalversions/config/v1"
+	configlistersv1 "github.com/openshift/client-go/config/listers/config/v1"
+	"github.com/openshift/library-go/pkg/operator/events"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
+	"k8s.io/apimachinery/pkg/util/wait"
+	"k8s.io/client-go/tools/cache"
+	"k8s.io/client-go/util/workqueue"
+	"k8s.io/klog/v2"
+)
+
+type FeatureGateChangeHandlerFunc func(featureChange FeatureChange)
+
+// FeatureGateAccess is used to get a list of enabled and disabled featuregates.
+// Create a new instance using NewFeatureGateAccess.
+// To create one for unit testing, use NewHardcodedFeatureGateAccess.
+type FeatureGateAccess interface {
+	// SetChangeHandler can only be called before Run.
+	// The default change handler will exit 0 when the set of featuregates changes.
+	// That is usually the easiest and simplest thing for an *operator* to do.
+	// This also discourages direct operand reading since all operands restarting simultaneously is bad.
+	// This function allows changing that default behavior to something else (perhaps a channel notification for
+	// all impacted controllers in an operator.
+	// I doubt this will be worth the effort in the majority of cases.
+	SetChangeHandler(featureGateChangeHandlerFn FeatureGateChangeHandlerFunc)
+
+	// Run starts a go func that continously watches the set of featuregates enabled in the cluster.
+	Run(ctx context.Context)
+	// InitialFeatureGatesObserved returns a channel that is closed once the featuregates have
+	// been observed. Once closed, the CurrentFeatureGates method will return the current set of
+	// featuregates and will never return a non-nil error.
+	InitialFeatureGatesObserved() <-chan struct{}
+	// CurrentFeatureGates returns the list of enabled and disabled featuregates.
+	// It returns an error if the current set of featuregates is not known.
+	CurrentFeatureGates() (FeatureGate, error)
+	// AreInitialFeatureGatesObserved returns true if the initial featuregates have been observed.
+	AreInitialFeatureGatesObserved() bool
+}
+
+type Features struct {
+	Enabled  []configv1.FeatureGateName
+	Disabled []configv1.FeatureGateName
+}
+
+type FeatureChange struct {
+	Previous *Features
+	New      Features
+}
+
+type defaultFeatureGateAccess struct {
+	desiredVersion              string
+	missingVersionMarker        string
+	clusterVersionLister        configlistersv1.ClusterVersionLister
+	featureGateLister           configlistersv1.FeatureGateLister
+	initialFeatureGatesObserved chan struct{}
+
+	featureGateChangeHandlerFn FeatureGateChangeHandlerFunc
+
+	lock            sync.Mutex
+	started         bool
+	initialFeatures Features
+	currentFeatures Features
+
+	queue         workqueue.RateLimitingInterface
+	eventRecorder events.Recorder
+}
+
+// NewFeatureGateAccess returns a controller that keeps the list of enabled/disabled featuregates up to date.
+// desiredVersion is the version of this operator that would be set on the clusteroperator.status.versions.
+// missingVersionMarker is the stub version provided by the operator.  If that is also the desired version,
+// then the most either the desired clusterVersion or most recent version will be used.
+// clusterVersionInformer is used when desiredVersion and missingVersionMarker are the same to derive the "best" version
+// of featuregates to use.
+// featureGateInformer is used to track changes to the featureGates once they are initially set.
+// By default, when the enabled/disabled list  of featuregates changes, os.Exit is called.  This behavior can be
+// overridden by calling SetChangeHandler to whatever you wish the behavior to be.
+// A common construct is:
+/* go
+featureGateAccessor := NewFeatureGateAccess(args)
+go featureGateAccessor.Run(ctx)
+
+select{
+case <- featureGateAccessor.InitialFeatureGatesObserved():
+	featureGates, _ := featureGateAccessor.CurrentFeatureGates()
+	klog.Infof("FeatureGates initialized: knownFeatureGates=%v", featureGates.KnownFeatures())
+case <- time.After(1*time.Minute):
+	klog.Errorf("timed out waiting for FeatureGate detection")
+	return fmt.Errorf("timed out waiting for FeatureGate detection")
+}
+
+// whatever other initialization you have to do, at this point you have FeatureGates to drive your behavior.
+*/
+// That construct is easy.  It is better to use the .spec.observedConfiguration construct common in library-go operators
+// to avoid gating your general startup on FeatureGate determination, but if you haven't already got that mechanism
+// this construct is easy.
+func NewFeatureGateAccess(
+	desiredVersion, missingVersionMarker string,
+	clusterVersionInformer v1.ClusterVersionInformer,
+	featureGateInformer v1.FeatureGateInformer,
+	eventRecorder events.Recorder) FeatureGateAccess {
+	c := &defaultFeatureGateAccess{
+		desiredVersion:              desiredVersion,
+		missingVersionMarker:        missingVersionMarker,
+		clusterVersionLister:        clusterVersionInformer.Lister(),
+		featureGateLister:           featureGateInformer.Lister(),
+		initialFeatureGatesObserved: make(chan struct{}),
+		queue:                       workqueue.NewNamedRateLimitingQueue(workqueue.DefaultControllerRateLimiter(), "feature-gate-detector"),
+		eventRecorder:               eventRecorder,
+	}
+	c.SetChangeHandler(ForceExit)
+
+	// we aren't expecting many
+	clusterVersionInformer.Informer().AddEventHandler(cache.ResourceEventHandlerFuncs{
+		AddFunc: func(obj interface{}) {
+			c.queue.Add("cluster")
+		},
+		UpdateFunc: func(old, cur interface{}) {
+			c.queue.Add("cluster")
+		},
+		DeleteFunc: func(uncast interface{}) {
+			c.queue.Add("cluster")
+		},
+	})
+	featureGateInformer.Informer().AddEventHandler(cache.ResourceEventHandlerFuncs{
+		AddFunc: func(obj interface{}) {
+			c.queue.Add("cluster")
+		},
+		UpdateFunc: func(old, cur interface{}) {
+			c.queue.Add("cluster")
+		},
+		DeleteFunc: func(uncast interface{}) {
+			c.queue.Add("cluster")
+		},
+	})
+
+	return c
+}
+
+func ForceExit(featureChange FeatureChange) {
+	if featureChange.Previous != nil {
+		os.Exit(0)
+	}
+}
+
+func (c *defaultFeatureGateAccess) SetChangeHandler(featureGateChangeHandlerFn FeatureGateChangeHandlerFunc) {
+	c.lock.Lock()
+	defer c.lock.Unlock()
+
+	if c.started {
+		panic("programmer error, cannot update the change handler after starting")
+	}
+	c.featureGateChangeHandlerFn = featureGateChangeHandlerFn
+}
+
+func (c *defaultFeatureGateAccess) Run(ctx context.Context) {
+	defer utilruntime.HandleCrash()
+	defer c.queue.ShutDown()
+
+	klog.Infof("Starting feature-gate-detector")
+	defer klog.Infof("Shutting down feature-gate-detector")
+
+	go wait.UntilWithContext(ctx, c.runWorker, time.Second)
+
+	<-ctx.Done()
+}
+
+func (c *defaultFeatureGateAccess) syncHandler(ctx context.Context) error {
+	desiredVersion := c.desiredVersion
+	if c.missingVersionMarker == c.desiredVersion {
+		clusterVersion, err := c.clusterVersionLister.Get("version")
+		if apierrors.IsNotFound(err) {
+			return nil // we will be re-triggered when it is created
+		}
+		if err != nil {
+			return err
+		}
+
+		desiredVersion = clusterVersion.Status.Desired.Version
+		if len(desiredVersion) == 0 && len(clusterVersion.Status.History) > 0 {
+			desiredVersion = clusterVersion.Status.History[0].Version
+		}
+	}
+
+	featureGate, err := c.featureGateLister.Get("cluster")
+	if apierrors.IsNotFound(err) {
+		return nil // we will be re-triggered when it is created
+	}
+	if err != nil {
+		return err
+	}
+
+	features, err := featuresFromFeatureGate(featureGate, desiredVersion)
+	if err != nil {
+		return fmt.Errorf("unable to determine features: %w", err)
+	}
+
+	c.setFeatureGates(features)
+
+	return nil
+}
+
+func (c *defaultFeatureGateAccess) setFeatureGates(features Features) {
+	c.lock.Lock()
+	defer c.lock.Unlock()
+
+	var previousFeatures *Features
+	if c.AreInitialFeatureGatesObserved() {
+		t := c.currentFeatures
+		previousFeatures = &t
+	}
+
+	c.currentFeatures = features
+
+	if !c.AreInitialFeatureGatesObserved() {
+		c.initialFeatures = features
+		close(c.initialFeatureGatesObserved)
+		c.eventRecorder.Eventf("FeatureGatesInitialized", "FeatureGates updated to %#v", c.currentFeatures)
+	}
+
+	if previousFeatures == nil || !reflect.DeepEqual(*previousFeatures, c.currentFeatures) {
+		if previousFeatures != nil {
+			c.eventRecorder.Eventf("FeatureGatesModified", "FeatureGates updated to %#v", c.currentFeatures)
+		}
+
+		c.featureGateChangeHandlerFn(FeatureChange{
+			Previous: previousFeatures,
+			New:      c.currentFeatures,
+		})
+	}
+}
+
+func (c *defaultFeatureGateAccess) InitialFeatureGatesObserved() <-chan struct{} {
+	return c.initialFeatureGatesObserved
+}
+
+func (c *defaultFeatureGateAccess) AreInitialFeatureGatesObserved() bool {
+	select {
+	case <-c.InitialFeatureGatesObserved():
+		return true
+	default:
+		return false
+	}
+}
+
+func (c *defaultFeatureGateAccess) CurrentFeatureGates() (FeatureGate, error) {
+	c.lock.Lock()
+	defer c.lock.Unlock()
+
+	if !c.AreInitialFeatureGatesObserved() {
+		return nil, fmt.Errorf("featureGates not yet observed")
+	}
+	retEnabled := make([]configv1.FeatureGateName, len(c.currentFeatures.Enabled))
+	retDisabled := make([]configv1.FeatureGateName, len(c.currentFeatures.Disabled))
+	copy(retEnabled, c.currentFeatures.Enabled)
+	copy(retDisabled, c.currentFeatures.Disabled)
+
+	return NewFeatureGate(retEnabled, retDisabled), nil
+}
+
+func (c *defaultFeatureGateAccess) runWorker(ctx context.Context) {
+	for c.processNextWorkItem(ctx) {
+	}
+}
+
+func (c *defaultFeatureGateAccess) processNextWorkItem(ctx context.Context) bool {
+	dsKey, quit := c.queue.Get()
+	if quit {
+		return false
+	}
+	defer c.queue.Done(dsKey)
+
+	err := c.syncHandler(ctx)
+	if err == nil {
+		c.queue.Forget(dsKey)
+		return true
+	}
+
+	utilruntime.HandleError(fmt.Errorf("%v failed with : %v", dsKey, err))
+	c.queue.AddRateLimited(dsKey)
+
+	return true
+}
+
+func featuresFromFeatureGate(featureGate *configv1.FeatureGate, desiredVersion string) (Features, error) {
+	found := false
+	features := Features{}
+	for _, featureGateValues := range featureGate.Status.FeatureGates {
+		if featureGateValues.Version != desiredVersion {
+			continue
+		}
+		found = true
+		for _, enabled := range featureGateValues.Enabled {
+			features.Enabled = append(features.Enabled, enabled.Name)
+		}
+		for _, disabled := range featureGateValues.Disabled {
+			features.Disabled = append(features.Disabled, disabled.Name)
+		}
+		break
+	}
+
+	if !found {
+		return Features{}, fmt.Errorf("missing desired version %q in featuregates.config.openshift.io/cluster", desiredVersion)
+	}
+
+	return features, nil
+}

--- a/vendor/github.com/openshift/library-go/pkg/operator/configobserver/unstructured.go
+++ b/vendor/github.com/openshift/library-go/pkg/operator/configobserver/unstructured.go
@@ -1,0 +1,45 @@
+package configobserver
+
+import (
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+)
+
+// Pruned returns the unstructured filtered by the given paths, i.e. everything
+// outside of them will be dropped. The returned data structure might overlap
+// with the input, but the input is not mutated. In case of error for a path,
+// that path is dropped.
+func Pruned(obj map[string]interface{}, pths ...[]string) map[string]interface{} {
+	if obj == nil || len(pths) == 0 {
+		return obj
+	}
+
+	ret := map[string]interface{}{}
+	if len(pths) == 1 {
+		x, found, err := unstructured.NestedFieldCopy(obj, pths[0]...)
+		if err != nil || !found {
+			return ret
+		}
+		unstructured.SetNestedField(ret, x, pths[0]...)
+		return ret
+	}
+
+	for i, p := range pths {
+		x, found, err := unstructured.NestedFieldCopy(obj, p...)
+		if err != nil {
+			continue
+		}
+		if !found {
+			continue
+		}
+		if i < len(pths)-1 {
+			// this might be overwritten by a later path
+			x = runtime.DeepCopyJSONValue(x)
+		}
+		if err := unstructured.SetNestedField(ret, x, p...); err != nil {
+			continue
+		}
+	}
+
+	return ret
+}

--- a/vendor/github.com/openshift/library-go/pkg/operator/resourcesynccontroller/core.go
+++ b/vendor/github.com/openshift/library-go/pkg/operator/resourcesynccontroller/core.go
@@ -1,0 +1,72 @@
+package resourcesynccontroller
+
+import (
+	"crypto/x509"
+	"fmt"
+	"reflect"
+
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	corev1listers "k8s.io/client-go/listers/core/v1"
+	"k8s.io/client-go/util/cert"
+
+	"github.com/openshift/library-go/pkg/crypto"
+	"github.com/openshift/library-go/pkg/operator/certrotation"
+)
+
+func CombineCABundleConfigMaps(destinationConfigMap ResourceLocation, lister corev1listers.ConfigMapLister, additionalAnnotations certrotation.AdditionalAnnotations, inputConfigMaps ...ResourceLocation) (*corev1.ConfigMap, error) {
+	certificates := []*x509.Certificate{}
+	for _, input := range inputConfigMaps {
+		inputConfigMap, err := lister.ConfigMaps(input.Namespace).Get(input.Name)
+		if apierrors.IsNotFound(err) {
+			continue
+		}
+		if err != nil {
+			return nil, err
+		}
+
+		// configmaps must conform to this
+		inputContent := inputConfigMap.Data["ca-bundle.crt"]
+		if len(inputContent) == 0 {
+			continue
+		}
+		inputCerts, err := cert.ParseCertsPEM([]byte(inputContent))
+		if err != nil {
+			return nil, fmt.Errorf("configmap/%s in %q is malformed: %v", input.Name, input.Namespace, err)
+		}
+		certificates = append(certificates, inputCerts...)
+	}
+
+	certificates = crypto.FilterExpiredCerts(certificates...)
+	finalCertificates := []*x509.Certificate{}
+	// now check for duplicates. n^2, but super simple
+	for i := range certificates {
+		found := false
+		for j := range finalCertificates {
+			if reflect.DeepEqual(certificates[i].Raw, finalCertificates[j].Raw) {
+				found = true
+				break
+			}
+		}
+		if !found {
+			finalCertificates = append(finalCertificates, certificates[i])
+		}
+	}
+
+	caBytes, err := crypto.EncodeCertificates(finalCertificates...)
+	if err != nil {
+		return nil, err
+	}
+
+	cm := &corev1.ConfigMap{
+		ObjectMeta: certrotation.NewTLSArtifactObjectMeta(
+			destinationConfigMap.Name,
+			destinationConfigMap.Namespace,
+			additionalAnnotations,
+		),
+		Data: map[string]string{
+			"ca-bundle.crt": string(caBytes),
+		},
+	}
+	return cm, nil
+}

--- a/vendor/github.com/openshift/library-go/pkg/operator/resourcesynccontroller/interfaces.go
+++ b/vendor/github.com/openshift/library-go/pkg/operator/resourcesynccontroller/interfaces.go
@@ -1,0 +1,41 @@
+package resourcesynccontroller
+
+import "k8s.io/apimachinery/pkg/util/sets"
+
+// ResourceLocation describes coordinates for a resource to be synced
+type ResourceLocation struct {
+	Namespace string `json:"namespace"`
+	Name      string `json:"name"`
+
+	// Provider if set for the source location enhance the error message to point to the component which
+	// provide this resource.
+	Provider string `json:"provider,omitempty"`
+}
+
+// PreconditionsFulfilled is a function that indicates whether all prerequisites
+// are met and a resource can be synced.
+type preconditionsFulfilled func() (bool, error)
+
+func alwaysFulfilledPreconditions() (bool, error) { return true, nil }
+
+type syncRuleSource struct {
+	ResourceLocation
+	syncedKeys               sets.Set[string]       // defines the set of keys to sync from source to dest
+	preconditionsFulfilledFn preconditionsFulfilled // preconditions to fulfill before syncing the resource
+}
+
+type syncRules map[ResourceLocation]syncRuleSource
+
+var (
+	emptyResourceLocation = ResourceLocation{}
+)
+
+// ResourceSyncer allows changes to syncing rules by this controller
+type ResourceSyncer interface {
+	// SyncConfigMap indicates that a configmap should be copied from the source to the destination.  It will also
+	// mirror a deletion from the source.  If the source is a zero object the destination will be deleted.
+	SyncConfigMap(destination, source ResourceLocation) error
+	// SyncSecret indicates that a secret should be copied from the source to the destination.  It will also
+	// mirror a deletion from the source.  If the source is a zero object the destination will be deleted.
+	SyncSecret(destination, source ResourceLocation) error
+}

--- a/vendor/github.com/openshift/library-go/pkg/operator/resourcesynccontroller/resourcesync_controller.go
+++ b/vendor/github.com/openshift/library-go/pkg/operator/resourcesynccontroller/resourcesync_controller.go
@@ -1,0 +1,352 @@
+package resourcesynccontroller
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	applyoperatorv1 "github.com/openshift/client-go/operator/applyconfigurations/operator/v1"
+	"net/http"
+	"sort"
+	"strings"
+	"sync"
+	"time"
+
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/sets"
+	corev1client "k8s.io/client-go/kubernetes/typed/core/v1"
+
+	operatorv1 "github.com/openshift/api/operator/v1"
+
+	"github.com/openshift/library-go/pkg/controller/factory"
+	"github.com/openshift/library-go/pkg/operator/condition"
+	"github.com/openshift/library-go/pkg/operator/events"
+	"github.com/openshift/library-go/pkg/operator/management"
+	"github.com/openshift/library-go/pkg/operator/resource/resourceapply"
+	"github.com/openshift/library-go/pkg/operator/v1helpers"
+)
+
+// ResourceSyncController is a controller that will copy source configmaps and secrets to their destinations.
+// It will also mirror deletions by deleting destinations.
+type ResourceSyncController struct {
+	controllerInstanceName string
+	// syncRuleLock is used to ensure we avoid races on changes to syncing rules
+	syncRuleLock sync.RWMutex
+	// configMapSyncRules is a map from destination location to source location
+	configMapSyncRules syncRules
+	// secretSyncRules is a map from destination location to source location
+	secretSyncRules syncRules
+
+	// knownNamespaces is the list of namespaces we are watching.
+	knownNamespaces sets.Set[string]
+
+	configMapGetter            corev1client.ConfigMapsGetter
+	secretGetter               corev1client.SecretsGetter
+	kubeInformersForNamespaces v1helpers.KubeInformersForNamespaces
+	operatorConfigClient       v1helpers.OperatorClient
+
+	runFn   func(ctx context.Context, workers int)
+	syncCtx factory.SyncContext
+}
+
+var _ ResourceSyncer = &ResourceSyncController{}
+var _ factory.Controller = &ResourceSyncController{}
+
+// NewResourceSyncController creates ResourceSyncController.
+func NewResourceSyncController(
+	instanceName string,
+	operatorConfigClient v1helpers.OperatorClient,
+	kubeInformersForNamespaces v1helpers.KubeInformersForNamespaces,
+	secretsGetter corev1client.SecretsGetter,
+	configMapsGetter corev1client.ConfigMapsGetter,
+	eventRecorder events.Recorder,
+) *ResourceSyncController {
+	c := &ResourceSyncController{
+		controllerInstanceName: factory.ControllerInstanceName(instanceName, "ResourceSync"),
+		operatorConfigClient:   operatorConfigClient,
+
+		configMapSyncRules:         syncRules{},
+		secretSyncRules:            syncRules{},
+		kubeInformersForNamespaces: kubeInformersForNamespaces,
+		knownNamespaces:            kubeInformersForNamespaces.Namespaces(),
+
+		configMapGetter: v1helpers.CachedConfigMapGetter(configMapsGetter, kubeInformersForNamespaces),
+		secretGetter:    v1helpers.CachedSecretGetter(secretsGetter, kubeInformersForNamespaces),
+		syncCtx:         factory.NewSyncContext("ResourceSyncController", eventRecorder.WithComponentSuffix("resource-sync-controller")),
+	}
+
+	informers := []factory.Informer{
+		operatorConfigClient.Informer(),
+	}
+	for namespace := range kubeInformersForNamespaces.Namespaces() {
+		if len(namespace) == 0 {
+			continue
+		}
+		informer := kubeInformersForNamespaces.InformersFor(namespace)
+		informers = append(informers, informer.Core().V1().ConfigMaps().Informer())
+		informers = append(informers, informer.Core().V1().Secrets().Informer())
+	}
+
+	f := factory.New().
+		WithSync(c.Sync).
+		WithSyncContext(c.syncCtx).
+		WithInformers(informers...).
+		ResyncEvery(time.Minute).
+		ToController(
+			instanceName, // don't change what is passed here unless you also remove the old FooDegraded condition
+			eventRecorder.WithComponentSuffix("resource-sync-controller"),
+		)
+	c.runFn = f.Run
+
+	return c
+}
+
+func (c *ResourceSyncController) Run(ctx context.Context, workers int) {
+	c.runFn(ctx, workers)
+}
+
+func (c *ResourceSyncController) Name() string {
+	return c.controllerInstanceName
+}
+
+func (c *ResourceSyncController) SyncConfigMap(destination, source ResourceLocation) error {
+	return c.syncConfigMap(destination, source, alwaysFulfilledPreconditions)
+}
+
+func (c *ResourceSyncController) SyncPartialConfigMap(destination ResourceLocation, source ResourceLocation, keys ...string) error {
+	return c.syncConfigMap(destination, source, alwaysFulfilledPreconditions, keys...)
+}
+
+// SyncConfigMapConditionally adds a new configmap that the resource sync
+// controller will synchronise if the given precondition is fulfilled.
+func (c *ResourceSyncController) SyncConfigMapConditionally(destination, source ResourceLocation, preconditionsFulfilledFn preconditionsFulfilled) error {
+	return c.syncConfigMap(destination, source, preconditionsFulfilledFn)
+}
+
+func (c *ResourceSyncController) syncConfigMap(destination ResourceLocation, source ResourceLocation, preconditionsFulfilledFn preconditionsFulfilled, keys ...string) error {
+	if !c.knownNamespaces.Has(destination.Namespace) {
+		return fmt.Errorf("not watching namespace %q", destination.Namespace)
+	}
+	if source != emptyResourceLocation && !c.knownNamespaces.Has(source.Namespace) {
+		return fmt.Errorf("not watching namespace %q", source.Namespace)
+	}
+
+	c.syncRuleLock.Lock()
+	defer c.syncRuleLock.Unlock()
+	c.configMapSyncRules[destination] = syncRuleSource{
+		ResourceLocation:         source,
+		syncedKeys:               sets.New(keys...),
+		preconditionsFulfilledFn: preconditionsFulfilledFn,
+	}
+
+	// make sure the new rule is picked up
+	c.syncCtx.Queue().Add(c.syncCtx.QueueKey())
+	return nil
+}
+
+func (c *ResourceSyncController) SyncSecret(destination, source ResourceLocation) error {
+	return c.syncSecret(destination, source, alwaysFulfilledPreconditions)
+}
+
+func (c *ResourceSyncController) SyncPartialSecret(destination, source ResourceLocation, keys ...string) error {
+	return c.syncSecret(destination, source, alwaysFulfilledPreconditions, keys...)
+}
+
+// SyncSecretConditionally adds a new secret that the resource sync controller
+// will synchronise if the given precondition is fulfilled.
+func (c *ResourceSyncController) SyncSecretConditionally(destination, source ResourceLocation, preconditionsFulfilledFn preconditionsFulfilled) error {
+	return c.syncSecret(destination, source, preconditionsFulfilledFn)
+}
+
+func (c *ResourceSyncController) syncSecret(destination, source ResourceLocation, preconditionsFulfilledFn preconditionsFulfilled, keys ...string) error {
+	if !c.knownNamespaces.Has(destination.Namespace) {
+		return fmt.Errorf("not watching namespace %q", destination.Namespace)
+	}
+	if source != emptyResourceLocation && !c.knownNamespaces.Has(source.Namespace) {
+		return fmt.Errorf("not watching namespace %q", source.Namespace)
+	}
+
+	c.syncRuleLock.Lock()
+	defer c.syncRuleLock.Unlock()
+	c.secretSyncRules[destination] = syncRuleSource{
+		ResourceLocation:         source,
+		syncedKeys:               sets.New(keys...),
+		preconditionsFulfilledFn: preconditionsFulfilledFn,
+	}
+
+	// make sure the new rule is picked up
+	c.syncCtx.Queue().Add(c.syncCtx.QueueKey())
+	return nil
+}
+
+// errorWithProvider provides a finger of blame in case a source resource cannot be retrieved.
+func errorWithProvider(provider string, err error) error {
+	if len(provider) > 0 {
+		return fmt.Errorf("%w (check the %q that is supposed to provide this resource)", err, provider)
+	}
+	return err
+}
+
+func (c *ResourceSyncController) Sync(ctx context.Context, syncCtx factory.SyncContext) error {
+	operatorSpec, _, _, err := c.operatorConfigClient.GetOperatorState()
+	if err != nil {
+		return err
+	}
+
+	if !management.IsOperatorManaged(operatorSpec.ManagementState) {
+		return nil
+	}
+
+	c.syncRuleLock.RLock()
+	defer c.syncRuleLock.RUnlock()
+
+	errors := []error{}
+
+	for destination, source := range c.configMapSyncRules {
+		// skip the sync if the preconditions aren't fulfilled
+		if fulfilled, err := source.preconditionsFulfilledFn(); !fulfilled || err != nil {
+			if err != nil {
+				errors = append(errors, err)
+			}
+			continue
+		}
+
+		if source.ResourceLocation == emptyResourceLocation {
+			// use the cache to check whether the configmap exists in target namespace, if not skip the extra delete call.
+			if _, err := c.configMapGetter.ConfigMaps(destination.Namespace).Get(ctx, destination.Name, metav1.GetOptions{}); err != nil {
+				if !apierrors.IsNotFound(err) {
+					errors = append(errors, err)
+				}
+				continue
+			}
+			if err := c.configMapGetter.ConfigMaps(destination.Namespace).Delete(ctx, destination.Name, metav1.DeleteOptions{}); err != nil && !apierrors.IsNotFound(err) {
+				errors = append(errors, err)
+			}
+			continue
+		}
+
+		_, _, err := resourceapply.SyncPartialConfigMap(ctx, c.configMapGetter, syncCtx.Recorder(), source.Namespace, source.Name, destination.Namespace, destination.Name, source.syncedKeys, []metav1.OwnerReference{})
+		if err != nil {
+			errors = append(errors, errorWithProvider(source.Provider, err))
+		}
+	}
+	for destination, source := range c.secretSyncRules {
+		// skip the sync if the preconditions aren't fulfilled
+		if fulfilled, err := source.preconditionsFulfilledFn(); !fulfilled || err != nil {
+			if err != nil {
+				errors = append(errors, err)
+			}
+			continue
+		}
+
+		if source.ResourceLocation == emptyResourceLocation {
+			// use the cache to check whether the secret exists in target namespace, if not skip the extra delete call.
+			if _, err := c.secretGetter.Secrets(destination.Namespace).Get(ctx, destination.Name, metav1.GetOptions{}); err != nil {
+				if !apierrors.IsNotFound(err) {
+					errors = append(errors, err)
+				}
+				continue
+			}
+			if err := c.secretGetter.Secrets(destination.Namespace).Delete(ctx, destination.Name, metav1.DeleteOptions{}); err != nil && !apierrors.IsNotFound(err) {
+				errors = append(errors, err)
+			}
+			continue
+		}
+
+		_, _, err := resourceapply.SyncPartialSecret(ctx, c.secretGetter, syncCtx.Recorder(), source.Namespace, source.Name, destination.Namespace, destination.Name, source.syncedKeys, []metav1.OwnerReference{})
+		if err != nil {
+			errors = append(errors, errorWithProvider(source.Provider, err))
+		}
+	}
+
+	if len(errors) > 0 {
+		condition := applyoperatorv1.OperatorStatus().
+			WithConditions(applyoperatorv1.OperatorCondition().
+				WithType(condition.ResourceSyncControllerDegradedConditionType).
+				WithStatus(operatorv1.ConditionTrue).
+				WithReason("Error").
+				WithMessage(v1helpers.NewMultiLineAggregate(errors).Error()))
+		updateErr := c.operatorConfigClient.ApplyOperatorStatus(ctx, c.controllerInstanceName, condition)
+		if updateErr != nil {
+			return updateErr
+		}
+		return nil
+	}
+
+	condition := applyoperatorv1.OperatorStatus().
+		WithConditions(applyoperatorv1.OperatorCondition().
+			WithType(condition.ResourceSyncControllerDegradedConditionType).
+			WithStatus(operatorv1.ConditionFalse))
+	updateErr := c.operatorConfigClient.ApplyOperatorStatus(ctx, c.controllerInstanceName, condition)
+	if updateErr != nil {
+		return updateErr
+	}
+	return nil
+}
+
+func NewDebugHandler(controller *ResourceSyncController) http.Handler {
+	return &debugHTTPHandler{controller: controller}
+}
+
+type debugHTTPHandler struct {
+	controller *ResourceSyncController
+}
+
+type ResourceSyncRule struct {
+	Destination ResourceLocation `json:"destination"`
+	Source      syncRuleSource   `json:"source"`
+}
+
+type ResourceSyncRuleList []ResourceSyncRule
+
+func (l ResourceSyncRuleList) Len() int      { return len(l) }
+func (l ResourceSyncRuleList) Swap(i, j int) { l[i], l[j] = l[j], l[i] }
+func (l ResourceSyncRuleList) Less(i, j int) bool {
+	if strings.Compare(l[i].Source.Namespace, l[j].Source.Namespace) < 0 {
+		return true
+	}
+	if strings.Compare(l[i].Source.Namespace, l[j].Source.Namespace) > 0 {
+		return false
+	}
+	if strings.Compare(l[i].Source.Name, l[j].Source.Name) < 0 {
+		return true
+	}
+	return false
+}
+
+type ControllerSyncRules struct {
+	Secrets ResourceSyncRuleList `json:"secrets"`
+	Configs ResourceSyncRuleList `json:"configs"`
+}
+
+// ServeSyncRules provides a handler function to return the sync rules of the controller
+func (h *debugHTTPHandler) ServeHTTP(w http.ResponseWriter, req *http.Request) {
+	syncRules := ControllerSyncRules{ResourceSyncRuleList{}, ResourceSyncRuleList{}}
+
+	h.controller.syncRuleLock.RLock()
+	defer h.controller.syncRuleLock.RUnlock()
+	syncRules.Secrets = append(syncRules.Secrets, resourceSyncRuleList(h.controller.secretSyncRules)...)
+	syncRules.Configs = append(syncRules.Configs, resourceSyncRuleList(h.controller.configMapSyncRules)...)
+
+	data, err := json.Marshal(syncRules)
+	if err != nil {
+		w.Write([]byte(err.Error()))
+		w.WriteHeader(http.StatusInternalServerError)
+		return
+	}
+	w.Write(data)
+	w.WriteHeader(http.StatusOK)
+}
+
+func resourceSyncRuleList(syncRules syncRules) ResourceSyncRuleList {
+	rules := make(ResourceSyncRuleList, 0, len(syncRules))
+	for dest, src := range syncRules {
+		rule := ResourceSyncRule{
+			Source:      src,
+			Destination: dest,
+		}
+		rules = append(rules, rule)
+	}
+	sort.Sort(rules)
+	return rules
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -212,6 +212,7 @@ github.com/munnerz/goautoneg
 # github.com/openshift/api v0.0.0-20241121204516-053bb8a33f6d
 ## explicit; go 1.22.0
 github.com/openshift/api
+github.com/openshift/api/annotations
 github.com/openshift/api/apiserver
 github.com/openshift/api/apiserver/v1
 github.com/openshift/api/apps
@@ -227,6 +228,7 @@ github.com/openshift/api/config/v1
 github.com/openshift/api/config/v1alpha1
 github.com/openshift/api/console
 github.com/openshift/api/console/v1
+github.com/openshift/api/features
 github.com/openshift/api/helm
 github.com/openshift/api/helm/v1beta1
 github.com/openshift/api/image
@@ -324,6 +326,7 @@ github.com/openshift/client-go/operator/listers/operator/v1alpha1
 ## explicit; go 1.22.0
 github.com/openshift/library-go/pkg/apiserver/jsonpatch
 github.com/openshift/library-go/pkg/authorization/hardcodedauthorizer
+github.com/openshift/library-go/pkg/certs
 github.com/openshift/library-go/pkg/config/client
 github.com/openshift/library-go/pkg/config/clusteroperator/v1helpers
 github.com/openshift/library-go/pkg/config/clusterstatus
@@ -335,6 +338,10 @@ github.com/openshift/library-go/pkg/controller/factory
 github.com/openshift/library-go/pkg/controller/fileobserver
 github.com/openshift/library-go/pkg/crypto
 github.com/openshift/library-go/pkg/network
+github.com/openshift/library-go/pkg/operator/certrotation
+github.com/openshift/library-go/pkg/operator/condition
+github.com/openshift/library-go/pkg/operator/configobserver
+github.com/openshift/library-go/pkg/operator/configobserver/featuregates
 github.com/openshift/library-go/pkg/operator/deploymentcontroller
 github.com/openshift/library-go/pkg/operator/events
 github.com/openshift/library-go/pkg/operator/loglevel
@@ -343,6 +350,7 @@ github.com/openshift/library-go/pkg/operator/resource/resourceapply
 github.com/openshift/library-go/pkg/operator/resource/resourcehelper
 github.com/openshift/library-go/pkg/operator/resource/resourcemerge
 github.com/openshift/library-go/pkg/operator/resource/resourceread
+github.com/openshift/library-go/pkg/operator/resourcesynccontroller
 github.com/openshift/library-go/pkg/operator/staticresourcecontroller
 github.com/openshift/library-go/pkg/operator/status
 github.com/openshift/library-go/pkg/operator/v1helpers


### PR DESCRIPTION
Adds logic to watch and react to downstream feature gate changes by setting container env vars in `operator-controller-controller-manager` deployment manifests.
Incorporates the recommended `github.com/openshift/library-go` approach (see https://github.com/openshift/enhancements/blob/068e863988b58f70b5184e4ef49c0ad1c2913dfb/dev-guide/featuresets.md) to avoid duplicating this logic locally.

~As mentioned internally, there are still some things that need clarification - I'm raising them as comments here.~

@oceanc80 @joelanford 