### PR TITLE
OCPBUGS-49410: extend clusterrole with permissions for OCP observability

### DIFF
--- a/manifests/0000_51_olm_02_operator_clusterrole.yaml
+++ b/manifests/0000_51_olm_02_operator_clusterrole.yaml
@@ -68,6 +68,25 @@ rules:
   - apiGroups:
       - ""
     resources:
+      - endpoints
+    verbs:
+      - get
+      - list
+      - watch
+  # necessary for OCP monitoring
+  # together with endpoints, services, pods
+  - apiGroups:
+      - monitoring.coreos.com
+    resources:
+      - servicemonitors
+    verbs:
+      - create
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - ""
+    resources:
       - pods
     verbs:
       - get
@@ -170,10 +189,12 @@ rules:
     - bind
     resourceNames:
     - catalogd-manager-role
+    - catalogd-metrics-monitor-role
     - catalogd-metrics-reader
     - catalogd-proxy-role
     - catalogd-leader-election-role
     - operator-controller-manager-role
+    - operator-controller-metrics-monitor-role
     - operator-controller-metrics-reader
     - operator-controller-proxy-role
     - operator-controller-leader-election-role


### PR DESCRIPTION
This adds the remaining necessary clusterrole permissions that cluster-olm-operator needs to be able to grant and act on for the catalogd and operator-controller to facilitate automatic metrics collection via OCP machinery

Specific necessary permissions are:
- create, read, list, watch servicemonitors
- read, list, watch endpoints, pods and services
- bind for the newly created metric monitor roles

part of OCPBUGS-49410 resolution
prerequisite for https://github.com/openshift/operator-framework-operator-controller/pull/252