### PR TITLE
OPRUN-3904: Add static network policies to govern namespace and controller pod

### DIFF
--- a/manifests/0000_51_olm_08_network_policy.yaml
+++ b/manifests/0000_51_olm_08_network_policy.yaml
@@ -1,0 +1,83 @@
+# See https://docs.google.com/document/d/1CDoGSRd-h8VT4PMrK_83Ro0YzYPjORbkxtfTJU1sN6Q/edit?tab=t.0
+# for more information on NetworkPolicies
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: default-deny-all
+  namespace: openshift-cluster-olm-operator
+  annotations:
+    include.release.openshift.io/self-managed-high-availability: "true"
+    capability.openshift.io/name: "OperatorLifecycleManagerV1"
+spec:
+  podSelector: {}
+  policyTypes:
+    - Ingress
+    - Egress
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: allow-egress-to-openshift-dns
+  namespace: openshift-cluster-olm-operator
+  annotations:
+    include.release.openshift.io/self-managed-high-availability: "true"
+    capability.openshift.io/name: "OperatorLifecycleManagerV1"
+spec:
+  egress:
+    - ports:
+        - protocol: TCP
+          port: dns-tcp
+        - protocol: UDP
+          port: dns
+      to:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: openshift-dns
+  podSelector:
+    matchLabels:
+      name: cluster-olm-operator
+  policyTypes:
+    - Egress
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: allow-egress-to-api-server
+  namespace: openshift-cluster-olm-operator
+  annotations:
+    include.release.openshift.io/self-managed-high-availability: "true"
+    capability.openshift.io/name: "OperatorLifecycleManagerV1"
+spec:
+  egress:
+    - ports:
+        - protocol: TCP
+          port: 6443
+  podSelector:
+    matchLabels:
+      name: cluster-olm-operator
+  policyTypes:
+    - Egress
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: allow-metrics-traffic
+  namespace: openshift-cluster-olm-operator
+  annotations:
+    include.release.openshift.io/self-managed-high-availability: "true"
+    capability.openshift.io/name: "OperatorLifecycleManagerV1"
+spec:
+  ingress:
+    - ports:
+        - port: 8443
+          protocol: TCP
+      from:
+       - namespaceSelector:
+           matchLabels:
+             name: openshift-monitoring
+  podSelector:
+    matchLabels:
+      name: cluster-olm-operator
+  policyTypes:
+    - Ingress


### PR DESCRIPTION
Adds network policies to:
- deny all ingress/egress traffic in the namespace by default
- allow controller pods to access kube apiserver
- allow controller pods to access dns
- allow openshift-monitoring namespace to access the metrics endpoint

Note: when trying to hit the /metrics endpoint I'm getting a 500 error. I'm not sure if this is because I cannot hit it directly, because maybe we don't expose metrics, or because there's an issue with how the cluster-olm-operator is configured. If I try to look at the metrics from the dashboard but it doesn't seem to com up as a target. So, maybe we don't expose metrics...

```
[Internal Server Error: "/": subjectaccessreviews.authorization.k8s.io is forbidden: User "system:serviceaccount:openshift-cluster-olm-operator:cluster-olm-operator" cannot create resource "subjectaccessreviews" in API group "authorization.k8s.io" at the cluster scope
```

I'm not sure if its because I nee

Manual Tests:

### DNS

```
# connect to cluster-olm-pod
kubectl exec -n openshift-cluster-olm-operator pods/cluster-olm-operator-864cd9d78c-txw9m -it -- /bin/bash
```

```
dig https://google.com
...
;; Query time: 31 msec
;; SERVER: 172.30.0.10#53(172.30.0.10)
;; WHEN: Thu May 15 12:34:46 UTC 2025
;; MSG SIZE  rcvd: 138
```

### kube-apiserver

```
APISERVER=https://kubernetes.default.svc
SERVICEACCOUNT=/var/run/secrets/kubernetes.io/serviceaccount
TOKEN=$(cat ${SERVICEACCOUNT}/token)
CACERT=${SERVICEACCOUNT}/ca.crt

wget --header="Authorization: Bearer $TOKEN" \
     --ca-certificate=$CACERT \
     -qO - \
     ${APISERVER}/version
{
  "major": "1",
  "minor": "32",
  "gitVersion": "v1.32.4",
  "gitCommit": "e1680af9f4a50ba886ed5f5221b6cf8bd80ee6cf",
  "gitTreeState": "clean",
  "buildDate": "2025-05-14T00:19:17Z",
  "goVersion": "go1.23.6 (Red Hat 1.23.6-2.el9_6) X:strictfipsruntime",
  "compiler": "gc",
  "platform": "linux/amd64"
}
```

### not kubeapi-server

```
wget https://www.google.com
--2025-05-15 12:52:32--  https://www.google.com/
Resolving www.google.com (www.google.com)... 192.178.155.99, 192.178.155.104, 192.178.155.106, ...
Connecting to www.google.com (www.google.com)|192.178.155.99|:443... timeout
```

### Metrics

From openshift-monitoring

```
wget https://cluster-olm-operator-metrics.openshift-cluster-olm-operator.svc --no-check-certificate
--2025-05-15 12:51:06--  https://cluster-olm-operator-metrics.openshift-cluster-olm-operator.svc/
Resolving cluster-olm-operator-metrics.openshift-cluster-olm-operator.svc (cluster-olm-operator-metrics.openshift-cluster-olm-operator.svc)... 172.30.5.236
Connecting to cluster-olm-operator-metrics.openshift-cluster-olm-operator.svc (cluster-olm-operator-metrics.openshift-cluster-olm-operator.svc)|172.30.5.236|:443... connected.
WARNING: cannot verify cluster-olm-operator-metrics.openshift-cluster-olm-operator.svc's certificate, issued by 'CN=openshift-service-serving-signer@1747305414':
  Self-signed certificate encountered.
HTTP request sent, awaiting response... 500 Internal Server Error
2025-05-15 12:51:06 ERROR 500: Internal Server Error.
```

From openshift-dns (i.e. not openshift-monitoring)

```
wget https://cluster-olm-operator-metrics.openshift-cluster-olm-operator.svc
--2025-05-15 12:51:52--  https://cluster-olm-operator-metrics.openshift-cluster-olm-operator.svc/
Resolving cluster-olm-operator-metrics.openshift-cluster-olm-operator.svc (cluster-olm-operator-metrics.openshift-cluster-olm-operator.svc)... 172.30.5.236
Connecting to cluster-olm-operator-metrics.openshift-cluster-olm-operator.svc (cluster-olm-operator-metrics.openshift-cluster-olm-operator.svc)|172.30.5.236|:443... timeout
```