### PR TITLE
OCPBUGS-56813: fix olm.maxOpenShiftVersion float parsing

### DIFF
--- a/cmd/cluster-olm-operator/main.go
+++ b/cmd/cluster-olm-operator/main.go
@@ -136,7 +136,7 @@ func runOperator(ctx context.Context, cc *controllercmd.ControllerContext) error
 	}
 
 	operatorImageVersion := status.VersionForOperatorFromEnv()
-	nextOCPMinorVersion, err := utils.GetNextOCPMinorVersion(operatorImageVersion)
+	currentOCPMinorVersion, err := utils.GetCurrentOCPMinorVersion(operatorImageVersion)
 	if err != nil {
 		return err
 	}
@@ -150,7 +150,7 @@ func runOperator(ctx context.Context, cc *controllercmd.ControllerContext) error
 
 	incompatibleOperatorController := controller.NewIncompatibleOperatorController(
 		"OLMIncompatibleOperatorController",
-		nextOCPMinorVersion,
+		currentOCPMinorVersion,
 		cl.KubeClient,
 		cl.ClusterExtensionClient,
 		cl.OperatorClient,

--- a/internal/utils/utils.go
+++ b/internal/utils/utils.go
@@ -3,20 +3,29 @@ package utils
 import (
 	"encoding/json"
 	"fmt"
+	"regexp"
 	"strings"
 
 	semver "github.com/blang/semver/v4"
 )
 
-func GetNextOCPMinorVersion(versionString string) (*semver.Version, error) {
+func GetCurrentOCPMinorVersion(versionString string) (*semver.Version, error) {
 	v, err := semver.Parse(versionString)
 	if err != nil {
 		return &v, err
 	}
-	v.Build = nil                 // Builds are irrelevant
-	v.Pre = nil                   // Next Y release
-	return &v, v.IncrementMinor() // Sets Y=Y+1 and Z=0
+	v.Patch = 0               // Patch is ignored (olm.maxOpenShiftVersion is <major>.<minor> only)
+	v.Pre, v.Build = nil, nil // Prerelease and Builds are ignored
+	return &v, nil
 }
+
+const (
+	majorMinorPattern = `([1-9][0-9]*)\.([1-9][0-9]*)`
+)
+
+var (
+	majorMinorRegex = regexp.MustCompile("^" + majorMinorPattern + "$")
+)
 
 func ToAllowedSemver(data []byte) (*semver.Version, error) {
 	var raw interface{}
@@ -28,15 +37,15 @@ func ToAllowedSemver(data []byte) (*semver.Version, error) {
 
 	switch v := raw.(type) {
 	case float64:
-		versionStr = fmt.Sprintf("%d.%d", int(v), int((v-float64(int(v)))*100)+1)
+		matches := majorMinorRegex.FindStringSubmatch(string(data))
+		if len(matches) != 3 {
+			return nil, fmt.Errorf("invalid semver format %q: expected <major>.<minor>", string(data))
+		}
+		versionStr = fmt.Sprintf("%s.%s", matches[1], matches[2])
 	case string:
 		versionStr = v
 	default:
 		return nil, fmt.Errorf("invalid type %T for olm.maxOpenshiftVersion: %s", v, string(data))
-	}
-
-	if !strings.Contains(versionStr, ".") || strings.Count(versionStr, ".") != 1 {
-		return nil, fmt.Errorf("invalid version format")
 	}
 
 	if strings.HasPrefix(versionStr, "v") || strings.Count(versionStr, ".") != 1 {
@@ -50,4 +59,14 @@ func ToAllowedSemver(data []byte) (*semver.Version, error) {
 	}
 
 	return &version, nil
+}
+
+// IsOperatorMaxOCPVersionCompatibleWithCluster compares the operator's maximum openshift version with the current cluster version
+// and returns whether the operator is compatible with the next cluster version. For example,
+//
+//	if maxOCPVersion is 4.18 and currentOCPMinorVersion is 4.17 => compatible
+//	if maxOCPVersion is 4.18 and currentOCPMinorVersion is 4.18 => incompatible
+//	if maxOCPVersion is 4.18 and currentOCPMinorVersion is 4.19 => incompatible
+func IsOperatorMaxOCPVersionCompatibleWithCluster(operatorMaxOCPVersion, currentOCPMinorVersion semver.Version) bool {
+	return operatorMaxOCPVersion.GT(currentOCPMinorVersion)
 }


### PR DESCRIPTION
Our float parsing logic for `olm.maxOpenShiftVersion` has a bug related to floating-point math. For example:
- `4.18 (float)` parsed to `4.18.0 (semver)`, but
- `4.19 (float)` parsed to `4.20.0 (semver)`

This PR resolves that bug, adds regression tests, and also does some slight refactoring to make the overall max OCP version logic easier to understand for maintainers.

