### PR TITLE
OPRUN-3970: Add support for experimental manifests

### DIFF
--- a/manifests/0000_51_olm_06_deployment.yaml
+++ b/manifests/0000_51_olm_06_deployment.yaml
@@ -32,7 +32,7 @@ spec:
           - /bin/sh
           args:
           - -c
-          - cp -a /openshift/manifests /operand-assets/catalogd
+          - if [ -e /cp-manifests ]; then /cp-manifests /operand-assets; else cp -a /openshift/manifests /operand-assets/catalogd; fi
           volumeMounts:
             - mountPath: /operand-assets
               name: operand-assets
@@ -44,7 +44,7 @@ spec:
           - /bin/sh
           args:
           - -c
-          - cp -a /openshift/manifests /operand-assets/operator-controller
+          - if [ -e /cp-manifests ]; then /cp-manifests /operand-assets; else cp -a /openshift/manifests /operand-assets/operator-controller; fi
           volumeMounts:
           - mountPath: /operand-assets
             name: operand-assets

--- a/pkg/controller/featuregates_hook.go
+++ b/pkg/controller/featuregates_hook.go
@@ -64,10 +64,7 @@ func UpdateDeploymentFeatureGatesHook(
 			if !strings.EqualFold(deployment.Spec.Template.Spec.Containers[i].Name, "manager") {
 				continue
 			}
-			err = setContainerArg(&deployment.Spec.Template.Spec.Containers[i], "--feature-gates", argToSet)
-			if err != nil {
-				errs = append(errs, err)
-			}
+			setContainerArg(&deployment.Spec.Template.Spec.Containers[i], "--feature-gates", argToSet)
 		}
 		if len(errs) > 0 {
 			return errors.Join(errs...)


### PR DESCRIPTION
Add support for experimental manifests in operator-controller and catalogd

When a new operator-controller or catalogd bundle has the experimental manifests, there will be a `/cp-manifests` script in the container to copy the images to appripriate (new) directories. If the `/cp-manifests` script does not exist, then the original method of copying the manifests is used.

When deciding upon which manifests to use, the code defaults to the original location. If the `standard` manifest location is found, it is used instead. If the `experimental` manifest location is found *and* the FeatureGate/FeatureSet is TechPreview, then the experimental manifests are used.

In addition, check for existing `--feature-gates` options and remove them before adding TechPreview enabled gates. This may mean there is a discrepency between the existing and new feature-gate flags. A check will be done in an upcoming commit to report discrepencies.