### PR TITLE
OPRUN-4026: Add support for all NoUpgrades

### DIFF
--- a/cmd/cluster-olm-operator/main.go
+++ b/cmd/cluster-olm-operator/main.go
@@ -107,8 +107,9 @@ func runOperator(ctx context.Context, cc *controllercmd.ControllerContext) error
 		if err != nil {
 			return fmt.Errorf("unable to retrieve featureSet: %w", err)
 		}
-		if strings.Contains(string(fg.Spec.FeatureSet), "TechPreview") {
-			log.Info("FeatureSet TechPreview enabled, using experimental manifests")
+		// Catches "CustomNoUpgrade", "TechPreviewNoUpgrade", "DevPreviewNoUpgrade"
+		if strings.Contains(string(fg.Spec.FeatureSet), "NoUpgrade") {
+			log.Info("Using experimental manifests", "featureSet", fg.Spec.FeatureSet)
 			assets = experimentalAssetPath
 		}
 	}


### PR DESCRIPTION
There are some people using DevPreviewNoUpgrade, and we aren't using the experimental manifests in that case.

We now handle Custom/DevPreview/TechPreview+NoUpgrade using the experimental manifests.