### PR TITLE
OPRUN-4521: handle OCP 4.23/5.0 upgrade boundary

### DIFF
--- a/internal/versionutils/version_utils.go
+++ b/internal/versionutils/version_utils.go
@@ -66,17 +66,17 @@ func ToAllowedSemver(data []byte) (*semver.Version, error) {
 var ocpVersion500 = semver.Version{Major: 5, Minor: 0, Patch: 0}
 
 // IsOperatorMaxOCPVersionCompatibleWithCluster compares the operator's maximum openshift version with the current cluster version
-// and returns whether the operator is compatible with the next cluster version. For example,
+// and returns whether the operator is upgradable to the next cluster version. For example,
 //
-//	if maxOCPVersion is 4.18 and currentOCPMinorVersion is 4.17 => compatible
-//	if maxOCPVersion is 4.18 and currentOCPMinorVersion is 4.18 => incompatible
-//	if maxOCPVersion is 4.18 and currentOCPMinorVersion is 4.19 => incompatible
-//	if maxOCPVersion is 5.0  and currentOCPMinorVersion is 4.23 => incompatible (next upgrade target is 5.1)
-//	if maxOCPVersion is 5.1  and currentOCPMinorVersion is 4.23 => compatible
+//	if maxOCPVersion is 4.18 and currentOCPMinorVersion is 4.17 => upgradable
+//	if maxOCPVersion is 4.18 and currentOCPMinorVersion is 4.18 => not upgradable
+//	if maxOCPVersion is 4.18 and currentOCPMinorVersion is 4.19 => not upgradable
+//	if maxOCPVersion is 5.0  and currentOCPMinorVersion is 4.23 => not upgradable (next upgrade target is 5.1)
+//	if maxOCPVersion is 5.1  and currentOCPMinorVersion is 4.23 => upgradable
 func IsOperatorMaxOCPVersionCompatibleWithCluster(operatorMaxOCPVersion, currentOCPMinorVersion semver.Version) bool {
 	effective := currentOCPMinorVersion
 	// OCP 4.23 and 5.0 are co-released equivalents; the only upgrade target from either is 5.1.
-	// Treat 4.23 as 5.0 so that operators must declare maxOCP > 5.0 (i.e. >= 5.1) to be compatible.
+	// Treat 4.23 as 5.0 so that operators must declare maxOCP > 5.0 (i.e. >= 5.1) to be upgradable.
 	if currentOCPMinorVersion.Major == 4 && currentOCPMinorVersion.Minor == 23 {
 		effective = ocpVersion500
 	}

--- a/internal/versionutils/version_utils.go
+++ b/internal/versionutils/version_utils.go
@@ -20,7 +20,7 @@ func GetCurrentOCPMinorVersion(versionString string) (*semver.Version, error) {
 }
 
 const (
-	majorMinorPattern = `([1-9][0-9]*)\.([1-9][0-9]*)`
+	majorMinorPattern = `([1-9][0-9]*)\.(0|[1-9][0-9]*)`
 )
 
 var (
@@ -28,7 +28,7 @@ var (
 )
 
 func ToAllowedSemver(data []byte) (*semver.Version, error) {
-	var raw interface{}
+	var raw any
 	if err := json.Unmarshal(data, &raw); err != nil {
 		return nil, err
 	}
@@ -61,12 +61,24 @@ func ToAllowedSemver(data []byte) (*semver.Version, error) {
 	return &version, nil
 }
 
+// ocpVersion500 is the semver representation of OCP 5.0, which is co-released with 4.23 as an
+// equivalent release. Neither upgrades to the other; both upgrade exclusively to 5.1.
+var ocpVersion500 = semver.Version{Major: 5, Minor: 0, Patch: 0}
+
 // IsOperatorMaxOCPVersionCompatibleWithCluster compares the operator's maximum openshift version with the current cluster version
 // and returns whether the operator is compatible with the next cluster version. For example,
 //
 //	if maxOCPVersion is 4.18 and currentOCPMinorVersion is 4.17 => compatible
 //	if maxOCPVersion is 4.18 and currentOCPMinorVersion is 4.18 => incompatible
 //	if maxOCPVersion is 4.18 and currentOCPMinorVersion is 4.19 => incompatible
+//	if maxOCPVersion is 5.0  and currentOCPMinorVersion is 4.23 => incompatible (next upgrade target is 5.1)
+//	if maxOCPVersion is 5.1  and currentOCPMinorVersion is 4.23 => compatible
 func IsOperatorMaxOCPVersionCompatibleWithCluster(operatorMaxOCPVersion, currentOCPMinorVersion semver.Version) bool {
-	return operatorMaxOCPVersion.GT(currentOCPMinorVersion)
+	effective := currentOCPMinorVersion
+	// OCP 4.23 and 5.0 are co-released equivalents; the only upgrade target from either is 5.1.
+	// Treat 4.23 as 5.0 so that operators must declare maxOCP > 5.0 (i.e. >= 5.1) to be compatible.
+	if currentOCPMinorVersion.Major == 4 && currentOCPMinorVersion.Minor == 23 {
+		effective = ocpVersion500
+	}
+	return operatorMaxOCPVersion.GT(effective)
 }

--- a/internal/versionutils/version_utils.go
+++ b/internal/versionutils/version_utils.go
@@ -71,6 +71,9 @@ var ocpVersion500 = semver.Version{Major: 5, Minor: 0, Patch: 0}
 //	if maxOCPVersion is 4.18 and currentOCPMinorVersion is 4.17 => upgradable
 //	if maxOCPVersion is 4.18 and currentOCPMinorVersion is 4.18 => not upgradable
 //	if maxOCPVersion is 4.18 and currentOCPMinorVersion is 4.19 => not upgradable
+//
+// NOTE: OCP 4.23 and 5.0 are co-released equivalents so the only upgrade target from either is 5.1:
+//
 //	if maxOCPVersion is 5.0  and currentOCPMinorVersion is 4.23 => not upgradable (next upgrade target is 5.1)
 //	if maxOCPVersion is 5.1  and currentOCPMinorVersion is 4.23 => upgradable
 func IsOperatorMaxOCPVersionCompatibleWithCluster(operatorMaxOCPVersion, currentOCPMinorVersion semver.Version) bool {

--- a/internal/versionutils/version_utils_test.go
+++ b/internal/versionutils/version_utils_test.go
@@ -103,25 +103,25 @@ func TestIsOperatorMaxOCPVersionCompatibleWithCluster(t *testing.T) {
 		want                   bool
 	}{
 		{
-			name:                   "maxOCPVersion is 4.18, currentOCPMinorVersion is 4.17 => compatible",
+			name:                   "maxOCPVersion is 4.18, currentOCPMinorVersion is 4.17 => upgradable",
 			operatorMaxOCPVersion:  semver.Version{Major: 4, Minor: 18, Patch: 0},
 			currentOCPMinorVersion: semver.Version{Major: 4, Minor: 17, Patch: 0},
 			want:                   true,
 		},
 		{
-			name:                   "maxOCPVersion is 4.18, currentOCPMinorVersion is 4.18 => incompatible",
+			name:                   "maxOCPVersion is 4.18, currentOCPMinorVersion is 4.18 => not upgradable",
 			operatorMaxOCPVersion:  semver.Version{Major: 4, Minor: 18, Patch: 0},
 			currentOCPMinorVersion: semver.Version{Major: 4, Minor: 18, Patch: 0},
 			want:                   false,
 		},
 		{
-			name:                   "maxOCPVersion is 4.18, currentOCPMinorVersion is 4.19 => incompatible",
+			name:                   "maxOCPVersion is 4.18, currentOCPMinorVersion is 4.19 => not upgradable",
 			operatorMaxOCPVersion:  semver.Version{Major: 4, Minor: 18, Patch: 0},
 			currentOCPMinorVersion: semver.Version{Major: 4, Minor: 19, Patch: 0},
 			want:                   false,
 		},
 		{
-			name:                   "maxOCPVersion is 4.23, currentOCPMinorVersion is 4.22 => compatible",
+			name:                   "maxOCPVersion is 4.23, currentOCPMinorVersion is 4.22 => upgradable",
 			operatorMaxOCPVersion:  semver.Version{Major: 4, Minor: 23, Patch: 0},
 			currentOCPMinorVersion: semver.Version{Major: 4, Minor: 22, Patch: 0},
 			want:                   true,
@@ -129,55 +129,55 @@ func TestIsOperatorMaxOCPVersionCompatibleWithCluster(t *testing.T) {
 		// 4.23/5.0/5.1 upgrade edge matrix.
 		// 4.23 and 5.0 are co-released equivalents; the only upgrade target from either is 5.1.
 		{
-			name:                   "maxOCPVersion is 4.23, currentOCPMinorVersion is 4.23 => incompatible",
+			name:                   "maxOCPVersion is 4.23, currentOCPMinorVersion is 4.23 => not upgradable",
 			operatorMaxOCPVersion:  semver.Version{Major: 4, Minor: 23, Patch: 0},
 			currentOCPMinorVersion: semver.Version{Major: 4, Minor: 23, Patch: 0},
 			want:                   false,
 		},
 		{
-			name:                   "maxOCPVersion is 5.0, currentOCPMinorVersion is 4.23 => incompatible (next upgrade target is 5.1)",
+			name:                   "maxOCPVersion is 5.0, currentOCPMinorVersion is 4.23 => not upgradable (next upgrade target is 5.1)",
 			operatorMaxOCPVersion:  semver.Version{Major: 5, Minor: 0, Patch: 0},
 			currentOCPMinorVersion: semver.Version{Major: 4, Minor: 23, Patch: 0},
 			want:                   false,
 		},
 		{
-			name:                   "maxOCPVersion is 5.1, currentOCPMinorVersion is 4.23 => compatible",
+			name:                   "maxOCPVersion is 5.1, currentOCPMinorVersion is 4.23 => upgradable",
 			operatorMaxOCPVersion:  semver.Version{Major: 5, Minor: 1, Patch: 0},
 			currentOCPMinorVersion: semver.Version{Major: 4, Minor: 23, Patch: 0},
 			want:                   true,
 		},
 		{
-			name:                   "maxOCPVersion is 4.23, currentOCPMinorVersion is 5.0 => incompatible",
+			name:                   "maxOCPVersion is 4.23, currentOCPMinorVersion is 5.0 => not upgradable",
 			operatorMaxOCPVersion:  semver.Version{Major: 4, Minor: 23, Patch: 0},
 			currentOCPMinorVersion: semver.Version{Major: 5, Minor: 0, Patch: 0},
 			want:                   false,
 		},
 		{
-			name:                   "maxOCPVersion is 5.0, currentOCPMinorVersion is 5.0 => incompatible",
+			name:                   "maxOCPVersion is 5.0, currentOCPMinorVersion is 5.0 => not upgradable",
 			operatorMaxOCPVersion:  semver.Version{Major: 5, Minor: 0, Patch: 0},
 			currentOCPMinorVersion: semver.Version{Major: 5, Minor: 0, Patch: 0},
 			want:                   false,
 		},
 		{
-			name:                   "maxOCPVersion is 5.1, currentOCPMinorVersion is 5.0 => compatible",
+			name:                   "maxOCPVersion is 5.1, currentOCPMinorVersion is 5.0 => upgradable",
 			operatorMaxOCPVersion:  semver.Version{Major: 5, Minor: 1, Patch: 0},
 			currentOCPMinorVersion: semver.Version{Major: 5, Minor: 0, Patch: 0},
 			want:                   true,
 		},
 		{
-			name:                   "maxOCPVersion is 4.23, currentOCPMinorVersion is 5.1 => incompatible",
+			name:                   "maxOCPVersion is 4.23, currentOCPMinorVersion is 5.1 => not upgradable",
 			operatorMaxOCPVersion:  semver.Version{Major: 4, Minor: 23, Patch: 0},
 			currentOCPMinorVersion: semver.Version{Major: 5, Minor: 1, Patch: 0},
 			want:                   false,
 		},
 		{
-			name:                   "maxOCPVersion is 5.0, currentOCPMinorVersion is 5.1 => incompatible",
+			name:                   "maxOCPVersion is 5.0, currentOCPMinorVersion is 5.1 => not upgradable",
 			operatorMaxOCPVersion:  semver.Version{Major: 5, Minor: 0, Patch: 0},
 			currentOCPMinorVersion: semver.Version{Major: 5, Minor: 1, Patch: 0},
 			want:                   false,
 		},
 		{
-			name:                   "maxOCPVersion is 5.1, currentOCPMinorVersion is 5.1 => incompatible",
+			name:                   "maxOCPVersion is 5.1, currentOCPMinorVersion is 5.1 => not upgradable",
 			operatorMaxOCPVersion:  semver.Version{Major: 5, Minor: 1, Patch: 0},
 			currentOCPMinorVersion: semver.Version{Major: 5, Minor: 1, Patch: 0},
 			want:                   false,

--- a/internal/versionutils/version_utils_test.go
+++ b/internal/versionutils/version_utils_test.go
@@ -57,6 +57,29 @@ func TestToAllowedSemver(t *testing.T) {
 			jsonInput: `"v4.18.0"`,
 			wantErr:   true,
 		},
+		{
+			name:      "valid float version 5.0",
+			jsonInput: `5.0`,
+			want:      &semver.Version{Major: 5, Minor: 0, Patch: 0},
+			wantErr:   false,
+		},
+		{
+			name:      "valid string version 5.0",
+			jsonInput: `"5.0"`,
+			want:      &semver.Version{Major: 5, Minor: 0, Patch: 0},
+			wantErr:   false,
+		},
+		{
+			name:      "valid string version 5.1",
+			jsonInput: `"5.1"`,
+			want:      &semver.Version{Major: 5, Minor: 1, Patch: 0},
+			wantErr:   false,
+		},
+		{
+			name:      "invalid float version with leading-zero minor 5.00",
+			jsonInput: `5.00`,
+			wantErr:   true,
+		},
 	}
 
 	for _, tt := range tests {
@@ -95,6 +118,68 @@ func TestIsOperatorMaxOCPVersionCompatibleWithCluster(t *testing.T) {
 			name:                   "maxOCPVersion is 4.18, currentOCPMinorVersion is 4.19 => incompatible",
 			operatorMaxOCPVersion:  semver.Version{Major: 4, Minor: 18, Patch: 0},
 			currentOCPMinorVersion: semver.Version{Major: 4, Minor: 19, Patch: 0},
+			want:                   false,
+		},
+		{
+			name:                   "maxOCPVersion is 4.23, currentOCPMinorVersion is 4.22 => compatible",
+			operatorMaxOCPVersion:  semver.Version{Major: 4, Minor: 23, Patch: 0},
+			currentOCPMinorVersion: semver.Version{Major: 4, Minor: 22, Patch: 0},
+			want:                   true,
+		},
+		// 4.23/5.0/5.1 upgrade edge matrix.
+		// 4.23 and 5.0 are co-released equivalents; the only upgrade target from either is 5.1.
+		{
+			name:                   "maxOCPVersion is 4.23, currentOCPMinorVersion is 4.23 => incompatible",
+			operatorMaxOCPVersion:  semver.Version{Major: 4, Minor: 23, Patch: 0},
+			currentOCPMinorVersion: semver.Version{Major: 4, Minor: 23, Patch: 0},
+			want:                   false,
+		},
+		{
+			name:                   "maxOCPVersion is 5.0, currentOCPMinorVersion is 4.23 => incompatible (next upgrade target is 5.1)",
+			operatorMaxOCPVersion:  semver.Version{Major: 5, Minor: 0, Patch: 0},
+			currentOCPMinorVersion: semver.Version{Major: 4, Minor: 23, Patch: 0},
+			want:                   false,
+		},
+		{
+			name:                   "maxOCPVersion is 5.1, currentOCPMinorVersion is 4.23 => compatible",
+			operatorMaxOCPVersion:  semver.Version{Major: 5, Minor: 1, Patch: 0},
+			currentOCPMinorVersion: semver.Version{Major: 4, Minor: 23, Patch: 0},
+			want:                   true,
+		},
+		{
+			name:                   "maxOCPVersion is 4.23, currentOCPMinorVersion is 5.0 => incompatible",
+			operatorMaxOCPVersion:  semver.Version{Major: 4, Minor: 23, Patch: 0},
+			currentOCPMinorVersion: semver.Version{Major: 5, Minor: 0, Patch: 0},
+			want:                   false,
+		},
+		{
+			name:                   "maxOCPVersion is 5.0, currentOCPMinorVersion is 5.0 => incompatible",
+			operatorMaxOCPVersion:  semver.Version{Major: 5, Minor: 0, Patch: 0},
+			currentOCPMinorVersion: semver.Version{Major: 5, Minor: 0, Patch: 0},
+			want:                   false,
+		},
+		{
+			name:                   "maxOCPVersion is 5.1, currentOCPMinorVersion is 5.0 => compatible",
+			operatorMaxOCPVersion:  semver.Version{Major: 5, Minor: 1, Patch: 0},
+			currentOCPMinorVersion: semver.Version{Major: 5, Minor: 0, Patch: 0},
+			want:                   true,
+		},
+		{
+			name:                   "maxOCPVersion is 4.23, currentOCPMinorVersion is 5.1 => incompatible",
+			operatorMaxOCPVersion:  semver.Version{Major: 4, Minor: 23, Patch: 0},
+			currentOCPMinorVersion: semver.Version{Major: 5, Minor: 1, Patch: 0},
+			want:                   false,
+		},
+		{
+			name:                   "maxOCPVersion is 5.0, currentOCPMinorVersion is 5.1 => incompatible",
+			operatorMaxOCPVersion:  semver.Version{Major: 5, Minor: 0, Patch: 0},
+			currentOCPMinorVersion: semver.Version{Major: 5, Minor: 1, Patch: 0},
+			want:                   false,
+		},
+		{
+			name:                   "maxOCPVersion is 5.1, currentOCPMinorVersion is 5.1 => incompatible",
+			operatorMaxOCPVersion:  semver.Version{Major: 5, Minor: 1, Patch: 0},
+			currentOCPMinorVersion: semver.Version{Major: 5, Minor: 1, Patch: 0},
 			want:                   false,
 		},
 	}

--- a/pkg/controller/incompatible_operator_controller.go
+++ b/pkg/controller/incompatible_operator_controller.go
@@ -145,7 +145,7 @@ func (c *incompatibleOperatorController) getIncompatibleOperatorsFromHelmRelease
 	store := c.buildHelmStore(c.kubeclient.CoreV1().Secrets("openshift-operator-controller"))
 
 	var errs []error
-	// Get all ClusterExtensions incompatible with next Y-stream
+	// Get all ClusterExtensions not upgradable to next Y-stream
 	for _, obj := range ceList {
 		metaObj, ok := obj.(metav1.Object)
 		if !ok {
@@ -205,7 +205,7 @@ func (c *incompatibleOperatorController) getIncompatibleOperatorsFromObjectSet()
 	}
 
 	var errs []error
-	// Get all ClusterExtensions incompatible with next Y-stream
+	// Get all ClusterExtensions not upgradable to next Y-stream
 	for _, obj := range ceList {
 		metaObj, ok := obj.(metav1.Object)
 		if !ok {
@@ -305,9 +305,9 @@ func (c *incompatibleOperatorController) checkIncompatibility(logger logr.Logger
 				continue
 			}
 
-			// 1. maxOCPVersion is 4.18, currentOCPMinorVersion is 4.17 => compatible
-			// 2. maxOCPVersion is 4.18, currentOCPMinorVersion is 4.18 => incompatible
-			// 3. maxOCPVersion is 4.18, currentOCPMinorVersion is 4.19 => incompatible
+			// 1. maxOCPVersion is 4.18, currentOCPMinorVersion is 4.17 => upgradable
+			// 2. maxOCPVersion is 4.18, currentOCPMinorVersion is 4.18 => not upgradable
+			// 3. maxOCPVersion is 4.18, currentOCPMinorVersion is 4.19 => not upgradable
 			isIncompatible = !versionutils.IsOperatorMaxOCPVersionCompatibleWithCluster(*maxOCPVersion, *c.currentOCPMinorVersion)
 		}
 	}

--- a/pkg/controller/incompatible_operator_controller_test.go
+++ b/pkg/controller/incompatible_operator_controller_test.go
@@ -317,6 +317,112 @@ func TestIncompatibleOperatorController_Sync(t *testing.T) {
 				messageContaining: "could not convert olm.properties",
 			},
 		},
+		// 4.23/5.0/5.1 upgrade edge cases.
+		// 4.23 and 5.0 are co-released equivalents; the only upgrade target from either is 5.1.
+		{
+			name: "boxcutter: maxOCPVersion=5.0 with cluster at 4.23 is incompatible (next upgrade target is 5.1)",
+			args: args{
+				clusterExtensions: []runtime.Object{
+					createClusterExtension("test-operator"),
+				},
+				clusterExtensionRevisions: []runtime.Object{
+					createRevision("test-operator-rev1", 1, "Active", "test-operator", "test-bundle-1.0", olmPropertyAnnotation(`[{"type":"olm.maxOpenShiftVersion","value":"5.0"}]`)),
+				},
+				currentOCPVersion: "4.23.0",
+				boxCutterEnabled:  true,
+			},
+			wants: wants{
+				conditionStatus:   operatorv1.ConditionFalse,
+				conditionReason:   reasonIncompatibleOperatorsInstalled,
+				messageContaining: "test-bundle-1.0",
+			},
+		},
+		{
+			name: "boxcutter: maxOCPVersion=5.1 with cluster at 4.23 is compatible",
+			args: args{
+				clusterExtensions: []runtime.Object{
+					createClusterExtension("test-operator"),
+				},
+				clusterExtensionRevisions: []runtime.Object{
+					createRevision("test-operator-rev1", 1, "Active", "test-operator", "test-bundle-1.0", olmPropertyAnnotation(`[{"type":"olm.maxOpenShiftVersion","value":"5.1"}]`)),
+				},
+				currentOCPVersion: "4.23.0",
+				boxCutterEnabled:  true,
+			},
+			wants: wants{
+				conditionStatus: operatorv1.ConditionTrue,
+				conditionReason: "",
+			},
+		},
+		{
+			name: "boxcutter: maxOCPVersion=5.1 with cluster at 5.0 is compatible",
+			args: args{
+				clusterExtensions: []runtime.Object{
+					createClusterExtension("test-operator"),
+				},
+				clusterExtensionRevisions: []runtime.Object{
+					createRevision("test-operator-rev1", 1, "Active", "test-operator", "test-bundle-1.0", olmPropertyAnnotation(`[{"type":"olm.maxOpenShiftVersion","value":"5.1"}]`)),
+				},
+				currentOCPVersion: "5.0.0",
+				boxCutterEnabled:  true,
+			},
+			wants: wants{
+				conditionStatus: operatorv1.ConditionTrue,
+				conditionReason: "",
+			},
+		},
+		{
+			name: "helm: maxOCPVersion=5.0 with cluster at 4.23 is incompatible (next upgrade target is 5.1)",
+			args: args{
+				clusterExtensions: []runtime.Object{
+					createClusterExtension("test-operator"),
+				},
+				helmReleases: []runtime.Object{
+					createHelmReleaseSecret("test-operator", "test-bundle-1.0", "test-package", olmPropertyAnnotation(`[{"type":"olm.maxOpenShiftVersion","value":"5.0"}]`)),
+				},
+				currentOCPVersion: "4.23.0",
+				boxCutterEnabled:  false,
+			},
+			wants: wants{
+				conditionStatus:   operatorv1.ConditionFalse,
+				conditionReason:   reasonIncompatibleOperatorsInstalled,
+				messageContaining: "test-bundle-1.0",
+			},
+		},
+		{
+			name: "helm: maxOCPVersion=5.1 with cluster at 4.23 is compatible",
+			args: args{
+				clusterExtensions: []runtime.Object{
+					createClusterExtension("test-operator"),
+				},
+				helmReleases: []runtime.Object{
+					createHelmReleaseSecret("test-operator", "test-bundle-1.0", "test-package", olmPropertyAnnotation(`[{"type":"olm.maxOpenShiftVersion","value":"5.1"}]`)),
+				},
+				currentOCPVersion: "4.23.0",
+				boxCutterEnabled:  false,
+			},
+			wants: wants{
+				conditionStatus: operatorv1.ConditionTrue,
+				conditionReason: "",
+			},
+		},
+		{
+			name: "helm: maxOCPVersion=5.1 with cluster at 5.0 is compatible",
+			args: args{
+				clusterExtensions: []runtime.Object{
+					createClusterExtension("test-operator"),
+				},
+				helmReleases: []runtime.Object{
+					createHelmReleaseSecret("test-operator", "test-bundle-1.0", "test-package", olmPropertyAnnotation(`[{"type":"olm.maxOpenShiftVersion","value":"5.1"}]`)),
+				},
+				currentOCPVersion: "5.0.0",
+				boxCutterEnabled:  false,
+			},
+			wants: wants{
+				conditionStatus: operatorv1.ConditionTrue,
+				conditionReason: "",
+			},
+		},
 	}
 
 	for _, tt := range tests {

--- a/pkg/controller/incompatible_operator_controller_test.go
+++ b/pkg/controller/incompatible_operator_controller_test.go
@@ -325,8 +325,8 @@ func TestIncompatibleOperatorController_Sync(t *testing.T) {
 				clusterExtensions: []runtime.Object{
 					createClusterExtension("test-operator"),
 				},
-				clusterExtensionRevisions: []runtime.Object{
-					createRevision("test-operator-rev1", 1, "Active", "test-operator", "test-bundle-1.0", olmPropertyAnnotation(`[{"type":"olm.maxOpenShiftVersion","value":"5.0"}]`)),
+				clusterObjectSets: []runtime.Object{
+					createObjectSet("test-operator-rev1", 1, "Active", "test-operator", "test-bundle-1.0", olmPropertyAnnotation(`[{"type":"olm.maxOpenShiftVersion","value":"5.0"}]`)),
 				},
 				currentOCPVersion: "4.23.0",
 				boxCutterEnabled:  true,
@@ -343,8 +343,8 @@ func TestIncompatibleOperatorController_Sync(t *testing.T) {
 				clusterExtensions: []runtime.Object{
 					createClusterExtension("test-operator"),
 				},
-				clusterExtensionRevisions: []runtime.Object{
-					createRevision("test-operator-rev1", 1, "Active", "test-operator", "test-bundle-1.0", olmPropertyAnnotation(`[{"type":"olm.maxOpenShiftVersion","value":"5.1"}]`)),
+				clusterObjectSets: []runtime.Object{
+					createObjectSet("test-operator-rev1", 1, "Active", "test-operator", "test-bundle-1.0", olmPropertyAnnotation(`[{"type":"olm.maxOpenShiftVersion","value":"5.1"}]`)),
 				},
 				currentOCPVersion: "4.23.0",
 				boxCutterEnabled:  true,
@@ -360,8 +360,8 @@ func TestIncompatibleOperatorController_Sync(t *testing.T) {
 				clusterExtensions: []runtime.Object{
 					createClusterExtension("test-operator"),
 				},
-				clusterExtensionRevisions: []runtime.Object{
-					createRevision("test-operator-rev1", 1, "Active", "test-operator", "test-bundle-1.0", olmPropertyAnnotation(`[{"type":"olm.maxOpenShiftVersion","value":"5.1"}]`)),
+				clusterObjectSets: []runtime.Object{
+					createObjectSet("test-operator-rev1", 1, "Active", "test-operator", "test-bundle-1.0", olmPropertyAnnotation(`[{"type":"olm.maxOpenShiftVersion","value":"5.1"}]`)),
 				},
 				currentOCPVersion: "5.0.0",
 				boxCutterEnabled:  true,

--- a/pkg/controller/incompatible_operator_controller_test.go
+++ b/pkg/controller/incompatible_operator_controller_test.go
@@ -32,7 +32,7 @@ import (
 )
 
 // TestIncompatibleOperatorController_Sync tests the sync method which updates operator status conditions
-// based on the presence of incompatible operators
+// based on the presence of not upgradable operators
 func TestIncompatibleOperatorController_Sync(t *testing.T) {
 	type args struct {
 		clusterExtensions []runtime.Object
@@ -77,7 +77,7 @@ func TestIncompatibleOperatorController_Sync(t *testing.T) {
 			},
 		},
 		{
-			name: "boxcutter: compatible operator",
+			name: "boxcutter: upgradable operator",
 			args: args{
 				clusterExtensions: []runtime.Object{
 					createClusterExtension("test-operator"),
@@ -94,7 +94,7 @@ func TestIncompatibleOperatorController_Sync(t *testing.T) {
 			},
 		},
 		{
-			name: "boxcutter: operator without olm.properties is interpreted as compatible",
+			name: "boxcutter: operator without olm.properties is interpreted as upgradable",
 			args: args{
 				clusterExtensions: []runtime.Object{
 					createClusterExtension("test-operator"),
@@ -149,7 +149,7 @@ func TestIncompatibleOperatorController_Sync(t *testing.T) {
 			},
 		},
 		{
-			name: "boxcutter: incompatible operator found",
+			name: "boxcutter: not upgradable operator found",
 			args: args{
 				clusterExtensions: []runtime.Object{
 					createClusterExtension("test-operator"),
@@ -167,7 +167,7 @@ func TestIncompatibleOperatorController_Sync(t *testing.T) {
 			},
 		},
 		{
-			name: "boxcutter: incompatible operator with multiple revisions found",
+			name: "boxcutter: not upgradable operator with multiple revisions found",
 			args: args{
 				clusterExtensions: []runtime.Object{
 					createClusterExtension("test-operator"),
@@ -187,14 +187,14 @@ func TestIncompatibleOperatorController_Sync(t *testing.T) {
 			},
 		},
 		{
-			name: "boxcutter: compatible and incompatible operators",
+			name: "boxcutter: upgradable and not upgradable operators",
 			args: args{
 				clusterExtensions: []runtime.Object{
 					createClusterExtension("test-operator"),
 				},
 				clusterObjectSets: []runtime.Object{
 					createObjectSet("test-operator-rev1", 1, "Archived", "test-operator", "test-bundle-1.0", olmPropertyAnnotation(`[{"type":"olm.maxOpenShiftVersion","value":"4.17"}]`)),
-					// set the non-latest revision to a compatible value to ensure the latest revision value is the one being used
+					// set the non-latest revision to an upgradable value to ensure the latest revision value is the one being used
 					createObjectSet("test-operator-rev2", 2, "Active", "test-operator", "test-bundle-1.1", olmPropertyAnnotation(`[{"type":"olm.maxOpenShiftVersion","value":"4.18"}]`)),
 					createObjectSet("test-operator-rev3", 3, "Active", "test-operator", "test-bundle-1.2", olmPropertyAnnotation(`[{"type":"olm.maxOpenShiftVersion","value":"4.17"}]`)),
 				},
@@ -208,7 +208,7 @@ func TestIncompatibleOperatorController_Sync(t *testing.T) {
 			},
 		},
 		{
-			name: "helm: compatible operator",
+			name: "helm: upgradable operator",
 			args: args{
 				clusterExtensions: []runtime.Object{
 					createClusterExtension("test-operator"),
@@ -225,7 +225,7 @@ func TestIncompatibleOperatorController_Sync(t *testing.T) {
 			},
 		},
 		{
-			name: "helm: operator without olm.properties is interpreted as compatible",
+			name: "helm: operator without olm.properties is interpreted as upgradable",
 			args: args{
 				clusterExtensions: []runtime.Object{
 					createClusterExtension("test-operator"),
@@ -242,7 +242,7 @@ func TestIncompatibleOperatorController_Sync(t *testing.T) {
 			},
 		},
 		{
-			name: "helm: incompatible operator found",
+			name: "helm: not upgradable operator found",
 			args: args{
 				clusterExtensions: []runtime.Object{
 					createClusterExtension("test-operator"),
@@ -260,7 +260,7 @@ func TestIncompatibleOperatorController_Sync(t *testing.T) {
 			},
 		},
 		{
-			name: "helm: compatible and incompatible operators",
+			name: "helm: upgradable and not upgradable operators",
 			args: args{
 				clusterExtensions: []runtime.Object{
 					createClusterExtension("test-operator"),
@@ -320,7 +320,7 @@ func TestIncompatibleOperatorController_Sync(t *testing.T) {
 		// 4.23/5.0/5.1 upgrade edge cases.
 		// 4.23 and 5.0 are co-released equivalents; the only upgrade target from either is 5.1.
 		{
-			name: "boxcutter: maxOCPVersion=5.0 with cluster at 4.23 is incompatible (next upgrade target is 5.1)",
+			name: "boxcutter: maxOCPVersion=5.0 with cluster at 4.23 is not upgradable (next upgrade target is 5.1)",
 			args: args{
 				clusterExtensions: []runtime.Object{
 					createClusterExtension("test-operator"),
@@ -338,7 +338,7 @@ func TestIncompatibleOperatorController_Sync(t *testing.T) {
 			},
 		},
 		{
-			name: "boxcutter: maxOCPVersion=5.1 with cluster at 4.23 is compatible",
+			name: "boxcutter: maxOCPVersion=5.1 with cluster at 4.23 is upgradable",
 			args: args{
 				clusterExtensions: []runtime.Object{
 					createClusterExtension("test-operator"),
@@ -355,7 +355,7 @@ func TestIncompatibleOperatorController_Sync(t *testing.T) {
 			},
 		},
 		{
-			name: "boxcutter: maxOCPVersion=5.1 with cluster at 5.0 is compatible",
+			name: "boxcutter: maxOCPVersion=5.1 with cluster at 5.0 is upgradable",
 			args: args{
 				clusterExtensions: []runtime.Object{
 					createClusterExtension("test-operator"),
@@ -372,7 +372,7 @@ func TestIncompatibleOperatorController_Sync(t *testing.T) {
 			},
 		},
 		{
-			name: "helm: maxOCPVersion=5.0 with cluster at 4.23 is incompatible (next upgrade target is 5.1)",
+			name: "helm: maxOCPVersion=5.0 with cluster at 4.23 is not upgradable (next upgrade target is 5.1)",
 			args: args{
 				clusterExtensions: []runtime.Object{
 					createClusterExtension("test-operator"),
@@ -390,7 +390,7 @@ func TestIncompatibleOperatorController_Sync(t *testing.T) {
 			},
 		},
 		{
-			name: "helm: maxOCPVersion=5.1 with cluster at 4.23 is compatible",
+			name: "helm: maxOCPVersion=5.1 with cluster at 4.23 is upgradable",
 			args: args{
 				clusterExtensions: []runtime.Object{
 					createClusterExtension("test-operator"),
@@ -407,7 +407,7 @@ func TestIncompatibleOperatorController_Sync(t *testing.T) {
 			},
 		},
 		{
-			name: "helm: maxOCPVersion=5.1 with cluster at 5.0 is compatible",
+			name: "helm: maxOCPVersion=5.1 with cluster at 5.0 is upgradable",
 			args: args{
 				clusterExtensions: []runtime.Object{
 					createClusterExtension("test-operator"),


### PR DESCRIPTION
OCP 4.23 and OCP 5.0 are considered equivalent releases, so 4.23 clusters cannot upgrade to OCP 5.0.
Next allowed release is 5.1.
Normalize currentOCPMinorVersion 4.23 → 5.0 before comparing with operator's maxOpenShiftVersion, tighten regex to reject leading-zero minor versions, and extend test coverage for the boundary cases.

[OPRUN-4521](https://redhat.atlassian.net/browse/OPRUN-4521)