### PR TITLE
OCPBUGS-77899: Fix wait logic to handle NewOLM enabled on Default Feature

### DIFF
--- a/cmd/cluster-olm-operator/main.go
+++ b/cmd/cluster-olm-operator/main.go
@@ -383,14 +383,16 @@ func runOperator(ctx context.Context, cc *controllercmd.ControllerContext) error
 		}(c)
 	}
 
-	// Wait for RBAC to be properly configured before starting deployment controllers.
-	// This prevents SCC validation failures when operator-controller-controller-manager
-	// pods are created before the ServiceAccount has access to the privileged SCC.
-	// Only run this check in experimental feature sets (TechPreview, DevPreview, CustomNoUpgrade)
-	// where operator-controller is actually deployed. In Default mode, operator-controller
-	// is not deployed, so the ServiceAccount doesn't exist and the check would timeout.
+	// Wait for operator-controller RBAC if it will be deployed.
+	// Must match the deployment decision in renderHelmTemplate (helm.go).
 	// See: OCPBUGS-77899
-	if cb.UseExperimentalFeatureSet() {
+	hasEnabledFeatureGates, err := cb.HasEnabledDownstreamFeatureGates(currentFeatureGates)
+	if err != nil {
+		return fmt.Errorf("unable to determine if operator-controller will be deployed: %w", err)
+	}
+	shouldWaitForOperatorController := cb.UseExperimentalFeatureSet() || hasEnabledFeatureGates
+
+	if shouldWaitForOperatorController {
 		// First, wait for the static resource controllers to create the namespace and ServiceAccount.
 		// The static controllers run asynchronously in goroutines, so we need to poll until the
 		// resources exist before we can verify RBAC propagation.

--- a/pkg/controller/builder.go
+++ b/pkg/controller/builder.go
@@ -183,6 +183,22 @@ func (b *Builder) CurrentFeatureGates() (featuregates.FeatureGate, error) {
 	return NewFeatureGate(enabledFeatures, disabledFeatures), nil
 }
 
+// HasEnabledDownstreamFeatureGates checks if any downstream feature gates
+// that map to operator-controller or catalogd are enabled in the cluster.
+// Returns true if at least one relevant feature gate is enabled.
+//
+// Callers should combine this result with UseExperimentalFeatureSet()
+// to determine if operator-controller should be deployed.
+func (b *Builder) HasEnabledDownstreamFeatureGates(clusterGatesConfig featuregates.FeatureGate) (bool, error) {
+	// Check if any downstream feature gates are enabled
+	for _, gate := range b.Clients.FeatureGateMapper.DownstreamFeatureGates() {
+		if clusterGatesConfig.Enabled(gate) {
+			return true, nil
+		}
+	}
+	return false, nil
+}
+
 // TODO: Remove the featureGate stuff to use the real thing
 type featureGate struct {
 	enabled  []configv1.FeatureGateName

--- a/pkg/controller/helm.go
+++ b/pkg/controller/helm.go
@@ -28,29 +28,22 @@ func (b *Builder) renderHelmTemplate(helmPath, manifestDir string) error {
 	log := klog.FromContext(context.Background()).WithName("renderHelmTemplate")
 	log.Info("Rendering Helm template", "source", helmPath, "destination", manifestDir)
 
-	useExperimental := b.UseExperimentalFeatureSet()
+	// Get current feature gates once and reuse
 	clusterGatesConfig, err := b.CurrentFeatureGates()
 	if err != nil {
 		return fmt.Errorf("CurrentFeatureGates failed: %w", err)
 	}
 
-	// Gather feature-gate configuration first, to see if we want to use
-	// the experimental values file.
-	featureGateValues, err := upstreamFeatureGates(
-		helmvalues.NewHelmValues(),
-		clusterGatesConfig,
-		b.Clients.FeatureGateMapper.DownstreamFeatureGates(),
-		b.Clients.FeatureGateMapper.UpstreamForDownstream)
+	// Check if any feature gates are enabled (without calling upstreamFeatureGates)
+	hasEnabledFeatureGates, err := b.HasEnabledDownstreamFeatureGates(clusterGatesConfig)
 	if err != nil {
-		return err
+		return fmt.Errorf("HasEnabledDownstreamFeatureGates failed: %w", err)
 	}
-	hasEnabledFeatureGates, err := featureGateValues.HasEnabledFeatureGates()
-	if err != nil {
-		return err
-	}
-	if hasEnabledFeatureGates {
-		useExperimental = true
-	}
+
+	// Determine if we should use experimental values file based on FeatureSet
+	// OR enabled feature gates. This uses the same logic as the RBAC wait check
+	// in main.go to ensure consistency.
+	useExperimental := b.UseExperimentalFeatureSet() || hasEnabledFeatureGates
 
 	// Determine and generate the values from the files (equivalent to --values)
 	valuesFiles := []string{filepath.Join(helmPath, "openshift.yaml")}
@@ -65,9 +58,8 @@ func (b *Builder) renderHelmTemplate(helmPath, manifestDir string) error {
 		return fmt.Errorf("error from GatherHelmValuesFromFiles: %w", err)
 	}
 
-	// Add the upstreamFeatureGates - this is run a second time to update the existing
-	// list rather than create a new list. Using AddValues() to merge featureGateValues
-	// from above would not allow overriding of enabled/disabled features.
+	// Add the upstreamFeatureGates to populate the actual helm values with enabled/disabled features.
+	// This is called only once here to merge feature gates into the values loaded from files.
 	values, err = upstreamFeatureGates(
 		values,
 		clusterGatesConfig,


### PR DESCRIPTION
Hi Team, 

Problem Statement                                                                                                                                                                                                                    
  When operator-controller is deployed in an OpenShift cluster, there is a race condition between:                                                                                                                
  1. The creation of RBAC resources (ClusterRoleBinding for SCC access)                                                                                                                                           
  2. The creation of the operator-controller Deployment                
                                                       
  If the Deployment is created before the RBAC permissions have fully propagated through the kube-apiserver's RBAC cache, the SCC admission plugin denies the pod creation, causing test failures: 
```                                                                  
  1 pods failed before test on SCC errors                                                                                                                                                                           
  Error creating: pods "operator-controller-controller-manager-67d5f76c87-" is forbidden:                                                                                                                           
  unable to validate against any security context constraint:                                                                                                                                                     
  provider "privileged": Forbidden: not usable by user or serviceaccount                                                                                                                                            
  for ReplicaSet.apps/v1/operator-controller-controller-manager-67d5f76c87 -n openshift-operator-controller                                                                                                         
  happened 12 times
```                                                                                                                                                                                                                                                                                                                                                                                                                                                                             
                                                                                                                                                                                                                    
Root Cause                                                                                                                                                                                                                                                                                                                                                                                                                        
  The cluster-olm-operator uses multiple controllers that run asynchronously:                                                                                                                                       
  - Static resource controllers create namespaces, ServiceAccounts, ClusterRoleBindings, and other RBAC resources
  - Deployment controllers create the actual Deployments                                                                                                                                                                                                                                                                                                                                                                              
  Both controller types start simultaneously, creating a race condition. Even though the ClusterRoleBinding is created first, there's a delay (typically a few seconds) before kube-apiserver's RBAC authorizer   
  cache refreshes and recognizes the new permissions. During this window, the SCC admission plugin rejects pod creation because it cannot validate the ServiceAccount's permissions.                                
   
Solution                                                                                                                                                                                                                                                                                                                                               
  1. Wait for resources to exist: Poll until the operator-controller ServiceAccount and namespace are created by static resource controllers                                                                        
  2. Wait for RBAC propagation: Use SubjectAccessReview API to verify that the ServiceAccount has the required SCC permissions (use verb on privileged SCC) before proceeding                                     
  3. Start deployment controllers: Only start deployment controllers after RBAC has fully propagated                                                                                                                
                                                                                                                                                                                                                    