### PR TITLE
OCPBUGS-88736: Apply cluster TLS security profile to the metrics server

### DIFF
--- a/cmd/cluster-olm-operator/main.go
+++ b/cmd/cluster-olm-operator/main.go
@@ -6,12 +6,15 @@ import (
 	goflag "flag"
 	"fmt"
 	"os"
+	"reflect"
 	"time"
 
 	configv1 "github.com/openshift/api/config/v1"
 	"github.com/openshift/cluster-olm-operator/internal/versionutils"
 
 	_ "github.com/openshift/api/operator/v1/zz_generated.crd-manifests"
+	configclient "github.com/openshift/client-go/config/clientset/versioned"
+	libgoclient "github.com/openshift/library-go/pkg/config/client"
 	"github.com/openshift/library-go/pkg/controller/controllercmd"
 	"github.com/openshift/library-go/pkg/controller/factory"
 	"github.com/openshift/library-go/pkg/operator/loglevel"
@@ -85,14 +88,52 @@ func newRootCommand() *cobra.Command {
 }
 
 func newStartCommand() *cobra.Command {
+	// metricsConfigFile is the temp file written by PersistentPreRunE and watched by
+	// controllercmd's WithRestartOnChange. It is shared with runOperator via the closure
+	// so that the TLS change handler can update it and trigger a graceful restart.
+	var metricsConfigFile string
+
 	cmd := controllercmd.NewControllerCommandConfig(
 		"cluster-olm-operator",
 		version.Get(),
-		runOperator,
+		func(ctx context.Context, cc *controllercmd.ControllerContext) error {
+			return runOperator(ctx, cc, metricsConfigFile)
+		},
 		clock.RealClock{},
 	).NewCommandWithContext(context.Background())
 	cmd.Use = "start"
 	cmd.Short = "Start the Cluster OLM Operator"
+
+	// Pre-configure the metrics server TLS from the cluster APIServer TLS profile before
+	// controllercmd starts the server. This runs only when --config is not already provided.
+	cmd.PersistentPreRunE = func(cmd *cobra.Command, _ []string) error {
+		if cmd.Flags().Changed("config") {
+			return nil
+		}
+		kubeConfig, err := libgoclient.GetKubeConfigOrInClusterConfig("", nil)
+		if err != nil {
+			klog.Warningf("Skipping metrics server TLS pre-configuration (no in-cluster config): %v", err)
+			return nil
+		}
+		cfgClient, err := configclient.NewForConfig(kubeConfig)
+		if err != nil {
+			klog.Warningf("Skipping metrics server TLS pre-configuration (config client error): %v", err)
+			return nil
+		}
+		servingInfo, err := controller.GetMetricsServerTLSServingInfo(context.Background(), cfgClient)
+		if err != nil || servingInfo.MinTLSVersion == "" {
+			klog.Warningf("Skipping metrics server TLS pre-configuration: %v", err)
+			return nil
+		}
+		configFile, err := controller.WriteMetricsServerConfigFile(servingInfo)
+		if err != nil {
+			klog.Warningf("Skipping metrics server TLS pre-configuration (write error): %v", err)
+			return nil
+		}
+		metricsConfigFile = configFile
+		return cmd.Flags().Set("config", configFile)
+	}
+
 	return cmd
 }
 
@@ -222,7 +263,7 @@ func waitForOperatorControllerRBAC(ctx context.Context, cl *clients.Clients, log
 	return nil
 }
 
-func runOperator(ctx context.Context, cc *controllercmd.ControllerContext) error {
+func runOperator(ctx context.Context, cc *controllercmd.ControllerContext, metricsConfigFile string) error {
 	cl, err := clients.New(cc)
 	if err != nil {
 		return err
@@ -394,6 +435,53 @@ func runOperator(ctx context.Context, cc *controllercmd.ControllerContext) error
 		UpdateFunc: func(_, newObj interface{}) { checkTopologyChange(newObj) },
 	}); err != nil {
 		return fmt.Errorf("failed to add infrastructure event handler: %w", err)
+	}
+
+	// When the TLS security profile changes the TLSObserverController stores the new
+	// settings in observedConfig, which the deployment hook then propagates to the operand
+	// Deployments. For the operator's own metrics server — which is configured at startup —
+	// we must restart the pod so PersistentPreRunE can re-read the new profile.
+	//
+	// We watch the operator client informer (not the APIServer informer) so that we fire
+	// only after the new config is already stored, avoiding a double-watch on the APIServer.
+	// The initial TLS profile is read directly from the APIServer so it matches what
+	// PersistentPreRunE used; this prevents a spurious restart on the first observer sync.
+	//
+	// Rather than calling os.Exit directly we update the config file that controllercmd's
+	// WithRestartOnChange is already watching — it detects the content change and performs
+	// a graceful restart for us.
+	initialTLSServingInfo, err := controller.GetMetricsServerTLSServingInfo(ctx, cl.ConfigClient)
+	if err != nil {
+		return fmt.Errorf("unable to retrieve initial TLS profile for metrics server: %w", err)
+	}
+	if _, err := cl.OperatorClient.Informer().AddEventHandler(cache.ResourceEventHandlerFuncs{
+		UpdateFunc: func(_, _ interface{}) {
+			operatorSpec, _, _, err := cl.OperatorClient.GetOperatorState()
+			if err != nil {
+				log.V(4).Info("Failed to get operator state in TLS change handler", "error", err)
+				return
+			}
+			newMinTLS, newCiphers := controller.TLSProfileFromObservedConfig(operatorSpec)
+			if newMinTLS == "" {
+				return // observer hasn't stored a TLS profile yet
+			}
+			if newMinTLS == initialTLSServingInfo.MinTLSVersion && reflect.DeepEqual(newCiphers, initialTLSServingInfo.CipherSuites) {
+				return // unchanged
+			}
+			log.Info("TLS security profile changed, updating metrics server config to trigger restart",
+				"old", initialTLSServingInfo.MinTLSVersion, "new", newMinTLS)
+			newServingInfo := configv1.HTTPServingInfo{
+				ServingInfo: configv1.ServingInfo{
+					MinTLSVersion: newMinTLS,
+					CipherSuites:  newCiphers,
+				},
+			}
+			if err := controller.UpdateMetricsServerConfigFile(metricsConfigFile, newServingInfo); err != nil {
+				klog.Warningf("Failed to update metrics server TLS config file: %v", err)
+			}
+		},
+	}); err != nil {
+		return fmt.Errorf("failed to add operator TLS change event handler: %w", err)
 	}
 
 	cl.StartInformers(ctx)

--- a/pkg/controller/metricsservertls.go
+++ b/pkg/controller/metricsservertls.go
@@ -1,0 +1,133 @@
+package controller
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+
+	configv1 "github.com/openshift/api/config/v1"
+	operatorv1 "github.com/openshift/api/operator/v1"
+	operatorv1alpha1 "github.com/openshift/api/operator/v1alpha1"
+	configclient "github.com/openshift/client-go/config/clientset/versioned"
+	"github.com/openshift/library-go/pkg/crypto"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+)
+
+// GetMetricsServerTLSServingInfo reads the cluster TLS security profile from the APIServer
+// config and returns a configv1.HTTPServingInfo populated with MinTLSVersion and CipherSuites.
+// Returns an empty HTTPServingInfo (with no error) if the APIServer resource is not found.
+func GetMetricsServerTLSServingInfo(ctx context.Context, configClient configclient.Interface) (configv1.HTTPServingInfo, error) {
+	apiServer, err := configClient.ConfigV1().APIServers().Get(ctx, "cluster", metav1.GetOptions{})
+	if apierrors.IsNotFound(err) {
+		return configv1.HTTPServingInfo{}, nil
+	}
+	if err != nil {
+		return configv1.HTTPServingInfo{}, fmt.Errorf("error reading APIServer config: %w", err)
+	}
+
+	minTLSVersion, cipherSuites := tlsSettingsFromProfile(apiServer.Spec.TLSSecurityProfile)
+	return configv1.HTTPServingInfo{
+		ServingInfo: configv1.ServingInfo{
+			MinTLSVersion: minTLSVersion,
+			CipherSuites:  cipherSuites,
+		},
+	}, nil
+}
+
+// tlsSettingsFromProfile extracts the minimum TLS version and IANA cipher suite names
+// from a TLSSecurityProfile. Mirrors the private getSecurityProfileCiphers in library-go.
+func tlsSettingsFromProfile(profile *configv1.TLSSecurityProfile) (string, []string) {
+	profileType := configv1.TLSProfileIntermediateType
+	if profile != nil {
+		profileType = profile.Type
+	}
+
+	var profileSpec *configv1.TLSProfileSpec
+	if profileType == configv1.TLSProfileCustomType {
+		if profile != nil && profile.Custom != nil {
+			profileSpec = &profile.Custom.TLSProfileSpec
+		}
+	} else {
+		profileSpec = configv1.TLSProfiles[profileType]
+	}
+
+	if profileSpec == nil {
+		profileSpec = configv1.TLSProfiles[configv1.TLSProfileIntermediateType]
+	}
+
+	return string(profileSpec.MinTLSVersion), crypto.OpenSSLToIANACipherSuites(profileSpec.Ciphers)
+}
+
+// TLSProfileFromObservedConfig extracts the TLS minVersion and cipherSuites stored in the
+// operator's observedConfig at the olmTLSSecurityProfile paths. Returns empty strings/nil
+// if the observedConfig is absent or unparseable.
+func TLSProfileFromObservedConfig(operatorSpec *operatorv1.OperatorSpec) (string, []string) {
+	if operatorSpec == nil || len(operatorSpec.ObservedConfig.Raw) == 0 {
+		return "", nil
+	}
+	var cfg map[string]interface{}
+	if err := json.Unmarshal(operatorSpec.ObservedConfig.Raw, &cfg); err != nil {
+		return "", nil
+	}
+	minTLS, _, _ := unstructured.NestedString(cfg, TLSMinVersionPath()...)
+	ciphers, _, _ := unstructured.NestedStringSlice(cfg, TLSCipherSuitesPath()...)
+	return minTLS, ciphers
+}
+
+// WriteMetricsServerConfigFile writes a GenericOperatorConfig JSON file containing the
+// given serving info to a temp file and returns the file path. The caller is responsible
+// for cleaning up the file when it is no longer needed.
+func WriteMetricsServerConfigFile(servingInfo configv1.HTTPServingInfo) (string, error) {
+	data, err := marshalServingConfig(servingInfo)
+	if err != nil {
+		return "", err
+	}
+
+	f, err := os.CreateTemp("", "cluster-olm-operator-tls-*.json")
+	if err != nil {
+		return "", fmt.Errorf("error creating temp TLS config file: %w", err)
+	}
+	defer f.Close()
+
+	if err := f.Chmod(0600); err != nil {
+		return "", fmt.Errorf("error setting TLS config file permissions: %w", err)
+	}
+
+	if _, err := f.Write(data); err != nil {
+		return "", fmt.Errorf("error writing TLS config file: %w", err)
+	}
+
+	return f.Name(), nil
+}
+
+// UpdateMetricsServerConfigFile overwrites the config file at path with new TLS serving
+// info. controllercmd's WithRestartOnChange watches the config file and triggers a graceful
+// restart when its content changes, so the metrics server picks up the new TLS settings.
+func UpdateMetricsServerConfigFile(path string, servingInfo configv1.HTTPServingInfo) error {
+	if path == "" {
+		return nil
+	}
+	data, err := marshalServingConfig(servingInfo)
+	if err != nil {
+		return err
+	}
+	return os.WriteFile(path, data, 0600)
+}
+
+func marshalServingConfig(servingInfo configv1.HTTPServingInfo) ([]byte, error) {
+	config := operatorv1alpha1.GenericOperatorConfig{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: "operator.openshift.io/v1alpha1",
+			Kind:       "GenericOperatorConfig",
+		},
+		ServingInfo: servingInfo,
+	}
+	data, err := json.Marshal(config)
+	if err != nil {
+		return nil, fmt.Errorf("error marshaling TLS serving config: %w", err)
+	}
+	return data, nil
+}

--- a/pkg/controller/metricsservertls_test.go
+++ b/pkg/controller/metricsservertls_test.go
@@ -1,0 +1,193 @@
+package controller
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"os"
+	"testing"
+
+	configv1 "github.com/openshift/api/config/v1"
+	operatorv1alpha1 "github.com/openshift/api/operator/v1alpha1"
+	configclient "github.com/openshift/client-go/config/clientset/versioned"
+	configv1typed "github.com/openshift/client-go/config/clientset/versioned/typed/config/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+)
+
+// fakeAPIServerGetter is a minimal configclient.Interface that returns a fixed APIServer.
+type fakeAPIServerGetter struct {
+	configclient.Interface // embed to satisfy interface; only ConfigV1().APIServers().Get is exercised
+	apiServer              *configv1.APIServer
+	err                    error
+}
+
+func (f *fakeAPIServerGetter) ConfigV1() configv1typed.ConfigV1Interface {
+	return &fakeConfigV1Client{apiServer: f.apiServer, err: f.err}
+}
+
+type fakeConfigV1Client struct {
+	configv1typed.ConfigV1Interface
+	apiServer *configv1.APIServer
+	err       error
+}
+
+func (f *fakeConfigV1Client) APIServers() configv1typed.APIServerInterface {
+	return &fakeAPIServerClient{apiServer: f.apiServer, err: f.err}
+}
+
+type fakeAPIServerClient struct {
+	configv1typed.APIServerInterface
+	apiServer *configv1.APIServer
+	err       error
+}
+
+func (f *fakeAPIServerClient) Get(_ context.Context, _ string, _ metav1.GetOptions) (*configv1.APIServer, error) {
+	return f.apiServer, f.err
+}
+
+func TestTLSSettingsFromProfile(t *testing.T) {
+	tests := []struct {
+		name                string
+		profile             *configv1.TLSSecurityProfile
+		wantMinTLSVersion   string
+		wantCipherSuitesDep bool // whether cipherSuites should be non-empty
+	}{
+		{
+			name:                "nil profile defaults to Intermediate",
+			profile:             nil,
+			wantMinTLSVersion:   string(configv1.TLSProfiles[configv1.TLSProfileIntermediateType].MinTLSVersion),
+			wantCipherSuitesDep: true,
+		},
+		{
+			name:                "Intermediate profile",
+			profile:             &configv1.TLSSecurityProfile{Type: configv1.TLSProfileIntermediateType},
+			wantMinTLSVersion:   string(configv1.TLSProfiles[configv1.TLSProfileIntermediateType].MinTLSVersion),
+			wantCipherSuitesDep: true,
+		},
+		{
+			name:                "Old profile",
+			profile:             &configv1.TLSSecurityProfile{Type: configv1.TLSProfileOldType},
+			wantMinTLSVersion:   string(configv1.TLSProfiles[configv1.TLSProfileOldType].MinTLSVersion),
+			wantCipherSuitesDep: true,
+		},
+		{
+			name:                "Modern profile",
+			profile:             &configv1.TLSSecurityProfile{Type: configv1.TLSProfileModernType},
+			wantMinTLSVersion:   string(configv1.TLSProfiles[configv1.TLSProfileModernType].MinTLSVersion),
+			wantCipherSuitesDep: true,
+		},
+		{
+			name: "Custom profile",
+			profile: &configv1.TLSSecurityProfile{
+				Type: configv1.TLSProfileCustomType,
+				Custom: &configv1.CustomTLSProfile{
+					TLSProfileSpec: configv1.TLSProfileSpec{
+						MinTLSVersion: configv1.VersionTLS13,
+						Ciphers:       []string{"ECDHE-ECDSA-AES256-GCM-SHA384"},
+					},
+				},
+			},
+			wantMinTLSVersion:   string(configv1.VersionTLS13),
+			wantCipherSuitesDep: true,
+		},
+		{
+			name:                "Custom profile with nil Custom spec falls back to Intermediate",
+			profile:             &configv1.TLSSecurityProfile{Type: configv1.TLSProfileCustomType},
+			wantMinTLSVersion:   string(configv1.TLSProfiles[configv1.TLSProfileIntermediateType].MinTLSVersion),
+			wantCipherSuitesDep: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			minTLS, ciphers := tlsSettingsFromProfile(tt.profile)
+			if minTLS != tt.wantMinTLSVersion {
+				t.Errorf("minTLSVersion = %q, want %q", minTLS, tt.wantMinTLSVersion)
+			}
+			if tt.wantCipherSuitesDep && len(ciphers) == 0 {
+				t.Error("expected non-empty cipherSuites")
+			}
+		})
+	}
+}
+
+func TestGetMetricsServerTLSServingInfo_NotFound(t *testing.T) {
+	client := &fakeAPIServerGetter{
+		err: apierrors.NewNotFound(schema.GroupResource{Resource: "apiservers"}, "cluster"),
+	}
+	info, err := GetMetricsServerTLSServingInfo(context.Background(), client)
+	if err != nil {
+		t.Fatalf("expected no error for NotFound, got: %v", err)
+	}
+	if info.MinTLSVersion != "" || len(info.CipherSuites) != 0 {
+		t.Error("expected empty HTTPServingInfo for NotFound")
+	}
+}
+
+func TestGetMetricsServerTLSServingInfo_Error(t *testing.T) {
+	client := &fakeAPIServerGetter{err: errors.New("connection refused")}
+	_, err := GetMetricsServerTLSServingInfo(context.Background(), client)
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+}
+
+func TestGetMetricsServerTLSServingInfo_IntermediateProfile(t *testing.T) {
+	client := &fakeAPIServerGetter{
+		apiServer: &configv1.APIServer{
+			Spec: configv1.APIServerSpec{
+				TLSSecurityProfile: &configv1.TLSSecurityProfile{
+					Type: configv1.TLSProfileIntermediateType,
+				},
+			},
+		},
+	}
+	info, err := GetMetricsServerTLSServingInfo(context.Background(), client)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	expectedMin := string(configv1.TLSProfiles[configv1.TLSProfileIntermediateType].MinTLSVersion)
+	if info.MinTLSVersion != expectedMin {
+		t.Errorf("MinTLSVersion = %q, want %q", info.MinTLSVersion, expectedMin)
+	}
+	if len(info.CipherSuites) == 0 {
+		t.Error("expected non-empty CipherSuites")
+	}
+}
+
+func TestWriteMetricsServerConfigFile(t *testing.T) {
+	servingInfo := configv1.HTTPServingInfo{
+		ServingInfo: configv1.ServingInfo{
+			MinTLSVersion: "VersionTLS12",
+			CipherSuites:  []string{"TLS_AES_128_GCM_SHA256", "TLS_AES_256_GCM_SHA384"},
+		},
+	}
+
+	path, err := WriteMetricsServerConfigFile(servingInfo)
+	if err != nil {
+		t.Fatalf("WriteMetricsServerConfigFile error: %v", err)
+	}
+	defer os.Remove(path)
+
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("error reading written config file: %v", err)
+	}
+
+	var config operatorv1alpha1.GenericOperatorConfig
+	if err := json.Unmarshal(data, &config); err != nil {
+		t.Fatalf("error unmarshaling config file: %v", err)
+	}
+
+	if config.ServingInfo.MinTLSVersion != "VersionTLS12" {
+		t.Errorf("MinTLSVersion = %q, want %q", config.ServingInfo.MinTLSVersion, "VersionTLS12")
+	}
+	if len(config.ServingInfo.CipherSuites) != 2 {
+		t.Errorf("CipherSuites len = %d, want 2", len(config.ServingInfo.CipherSuites))
+	}
+	if config.Kind != "GenericOperatorConfig" {
+		t.Errorf("Kind = %q, want GenericOperatorConfig", config.Kind)
+	}
+}


### PR DESCRIPTION
The cluster-olm-operator metrics server (port 8443) was using default TLS settings rather than the cluster-wide TLS security profile from apiservers.config.openshift.io/cluster. The profile was already applied to operator-controller and catalogd via UpdateDeploymentObservedConfigHook, but not to the operator's own serving endpoint.

Fix this with two coordinated mechanisms:

1. Pre-configure metrics server TLS at startup: a PersistentPreRunE hook in newStartCommand reads the cluster TLS profile from the APIServer before controllercmd starts the metrics server, writes a GenericOperatorConfig temp file with the correct minTLSVersion and cipherSuites, and sets --config to point to it. controllercmd's SetRecommendedHTTPServingInfoDefaults preserves non-empty values, so the TLS profile flows into the metrics server. The hook is skipped if --config is already explicitly provided.

2. Restart on profile change: runOperator watches the operator client informer (the OLM CR) rather than the APIServer directly, so the handler fires only after TLSObserverController has already written the new settings to observedConfig and the deployment hook has had a chance to update the operand Deployments. When the stored TLS profile diverges from what was read at startup, the handler overwrites the config file with the new TLS settings. controllercmd's existing WithRestartOnChange mechanism detects the file content change and performs a graceful restart, after which PersistentPreRunE re-reads the new profile and the metrics server starts with correct TLS.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * The operator’s metrics server now monitors the cluster’s TLS security profile and automatically updates its TLS configuration.
  * When the minimum TLS version or cipher suites change, the metrics server gracefully restarts to apply the new settings.
* **Tests**
  * Added unit coverage for TLS profile extraction, config generation, and metrics server TLS serving info behavior, including not-found and error scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->