### PR TITLE
OCPBUGS-94187: Scale to replicas=2 and enable PDB on HighlyAvailable topology [release-4.22]

### DIFF
--- a/cmd/cluster-olm-operator/main.go
+++ b/cmd/cluster-olm-operator/main.go
@@ -28,6 +28,7 @@ import (
 	"k8s.io/apimachinery/pkg/util/runtime"
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/apimachinery/pkg/util/wait"
+	cache "k8s.io/client-go/tools/cache"
 	"k8s.io/component-base/cli"
 	utilflag "k8s.io/component-base/cli/flag"
 	"k8s.io/klog/v2"
@@ -234,6 +235,11 @@ func runOperator(ctx context.Context, cc *controllercmd.ControllerContext) error
 		return fmt.Errorf("unable to retrieve featureSet: %w", err)
 	}
 
+	infra, err := cl.ConfigClient.ConfigV1().Infrastructures().Get(ctx, "cluster", metav1.GetOptions{})
+	if err != nil {
+		return fmt.Errorf("unable to retrieve infrastructure: %w", err)
+	}
+
 	clusterCatalogGvk := ocv1.GroupVersion.WithKind("ClusterCatalog")
 	cb := controller.Builder{
 		Assets:            assetPath,
@@ -246,7 +252,8 @@ func runOperator(ctx context.Context, cc *controllercmd.ControllerContext) error
 				Scope:            meta.RESTScopeRoot,
 			},
 		},
-		FeatureGate: *fg,
+		FeatureGate:    *fg,
+		Infrastructure: infra,
 	}
 
 	staticResourceControllers, deploymentControllers, clusterCatalogControllers, relatedObjects, err := cb.BuildControllers("catalogd", "operator-controller")
@@ -365,6 +372,29 @@ func runOperator(ctx context.Context, cc *controllercmd.ControllerContext) error
 	)
 
 	operatorLoggingController := loglevel.NewClusterOperatorLoggingController(cl.OperatorClient, cc.EventRecorder.ForComponent("ClusterOLMOperatorLoggingController"))
+
+	// Watch for infrastructure topology changes. Topology changes are exceedingly rare
+	// (e.g., SNO to HA conversion) but require re-rendering the Helm manifests with the
+	// correct replica count and PDB settings. Exiting causes the deployment controller to
+	// restart cluster-olm-operator, which re-renders the manifests on startup.
+	initialTopology := infra.Status.ControlPlaneTopology
+	checkTopologyChange := func(obj interface{}) {
+		newInfra, ok := obj.(*configv1.Infrastructure)
+		if !ok {
+			return
+		}
+		if newInfra.Status.ControlPlaneTopology != initialTopology {
+			log.Info("Infrastructure topology changed, restarting to re-render manifests",
+				"old", initialTopology, "new", newInfra.Status.ControlPlaneTopology)
+			os.Exit(0)
+		}
+	}
+	if _, err := cl.InfrastructureClient.Informer().AddEventHandler(cache.ResourceEventHandlerFuncs{
+		AddFunc:    checkTopologyChange,
+		UpdateFunc: func(_, newObj interface{}) { checkTopologyChange(newObj) },
+	}); err != nil {
+		return fmt.Errorf("failed to add infrastructure event handler: %w", err)
+	}
 
 	cl.StartInformers(ctx)
 

--- a/pkg/clients/clients.go
+++ b/pkg/clients/clients.go
@@ -64,6 +64,7 @@ type Clients struct {
 	ClusterObjectSetClient     *ClusterObjectSetClient
 	ClusterCatalogClient       *ClusterCatalogClient
 	ProxyClient                *ProxyClient
+	InfrastructureClient       *InfrastructureClient
 	ConfigClient               configclient.Interface
 	KubeInformerFactory        informers.SharedInformerFactory
 	ConfigInformerFactory      configinformer.SharedInformerFactory
@@ -128,6 +129,7 @@ func New(cc *controllercmd.ControllerContext) (*Clients, error) {
 		ClusterCatalogClient:   NewClusterCatalogClient(dynClient),
 		ClusterObjectSetClient: NewClusterObjectSetClient(dynClient),
 		ProxyClient:            NewProxyClient(configInformerFactory),
+		InfrastructureClient:   NewInfrastructureClient(configInformerFactory),
 		ConfigClient:           configClient,
 		KubeInformerFactory:    informers.NewSharedInformerFactory(kubeClient, defaultResyncPeriod),
 		ConfigInformerFactory:  configInformerFactory,
@@ -287,6 +289,28 @@ func NewProxyClient(infFact configinformer.SharedInformerFactory) *ProxyClient {
 	return &ProxyClient{
 		factory:  infFact,
 		informer: inf,
+	}
+}
+
+type InfrastructureClientInterface interface {
+	Get(key string) (*configv1.Infrastructure, error)
+}
+
+type InfrastructureClient struct {
+	informer configinformerv1.InfrastructureInformer
+}
+
+func (ic *InfrastructureClient) Informer() cache.SharedIndexInformer {
+	return ic.informer.Informer()
+}
+
+func (ic *InfrastructureClient) Get(key string) (*configv1.Infrastructure, error) {
+	return ic.informer.Lister().Get(key)
+}
+
+func NewInfrastructureClient(infFact configinformer.SharedInformerFactory) *InfrastructureClient {
+	return &InfrastructureClient{
+		informer: infFact.Config().V1().Infrastructures(),
 	}
 }
 

--- a/pkg/controller/builder.go
+++ b/pkg/controller/builder.go
@@ -45,6 +45,7 @@ type Builder struct {
 	ControllerContext *controllercmd.ControllerContext
 	KnownRESTMappings map[schema.GroupVersionKind]*meta.RESTMapping
 	FeatureGate       configv1.FeatureGate
+	Infrastructure    *configv1.Infrastructure
 }
 
 func (b *Builder) BuildControllers(subDirectories ...string) (map[string]factory.Controller, map[string]factory.Controller, map[string]factory.Controller, []configv1.ObjectReference, error) {

--- a/pkg/controller/helm.go
+++ b/pkg/controller/helm.go
@@ -9,6 +9,7 @@ import (
 	"regexp"
 	"strings"
 
+	configv1 "github.com/openshift/api/config/v1"
 	"github.com/openshift/cluster-olm-operator/pkg/helmvalues"
 
 	yaml3 "gopkg.in/yaml.v3"
@@ -78,6 +79,34 @@ func (b *Builder) renderHelmTemplate(helmPath, manifestDir string) error {
 	}
 	if err := values.SetStringValue("options.operatorController.deployment.image", os.Getenv("OPERATOR_CONTROLLER_IMAGE")); err != nil {
 		return fmt.Errorf("error setting OPERATOR_CONTROLLER_IMAGE: %w", err)
+	}
+
+	// On HighlyAvailable topologies scale to 2 replicas and enable the PDB so that rolling
+	// updates never leave zero running pods. On SingleReplica (SNO) / External topologies
+	// the manifest defaults (replicas=1, PDB disabled) are kept as-is.
+	if b.Infrastructure != nil && isHighlyAvailableTopology(b.Infrastructure) {
+		log.Info("HighlyAvailable topology detected, setting replicas=2 and enabling PDB")
+		haOverrides := []struct {
+			key   string
+			value interface{}
+		}{
+			{"options.catalogd.deployment.replicas", 2},
+			{"options.operatorController.deployment.replicas", 2},
+			{"options.catalogd.podDisruptionBudget.enabled", true},
+			{"options.operatorController.podDisruptionBudget.enabled", true},
+		}
+		for _, o := range haOverrides {
+			var err error
+			switch v := o.value.(type) {
+			case int:
+				err = values.SetIntValue(o.key, v)
+			case bool:
+				err = values.SetBoolValue(o.key, v)
+			}
+			if err != nil {
+				return fmt.Errorf("error setting %s: %w", o.key, err)
+			}
+		}
 	}
 
 	log.Info("Calculated values", "values", values.GetValues())
@@ -263,6 +292,16 @@ func sanitizeFilename(name string) string {
 	// Replace invalid characters with hyphens
 	reg := regexp.MustCompile(`[^a-zA-Z0-9.-]`)
 	return reg.ReplaceAllString(name, "-")
+}
+
+func isHighlyAvailableTopology(infra *configv1.Infrastructure) bool {
+	switch infra.Status.ControlPlaneTopology {
+	case configv1.HighlyAvailableTopologyMode,
+		configv1.HighlyAvailableArbiterMode,
+		configv1.DualReplicaTopologyMode:
+		return true
+	}
+	return false
 }
 
 func writeDocument(filePath, content string) error {

--- a/pkg/helmvalues/helmvalues.go
+++ b/pkg/helmvalues/helmvalues.go
@@ -82,6 +82,22 @@ func (v *HelmValues) SetStringValue(location string, newValue string) error {
 	return unstructured.SetNestedField(v.values, newValue, ss...)
 }
 
+func (v *HelmValues) SetIntValue(location string, newValue int) error {
+	if location == "" {
+		return errors.New("location string has no locations")
+	}
+	ss := strings.Split(location, ".")
+	return unstructured.SetNestedField(v.values, int64(newValue), ss...)
+}
+
+func (v *HelmValues) SetBoolValue(location string, newValue bool) error {
+	if location == "" {
+		return errors.New("location string has no locations")
+	}
+	ss := strings.Split(location, ".")
+	return unstructured.SetNestedField(v.values, newValue, ss...)
+}
+
 func (v *HelmValues) AddListValue(location string, newValue string) error {
 	if location == "" {
 		return errors.New("location string has no locations")


### PR DESCRIPTION
## Summary

Backport of [OCPBUGS-62517](https://redhat.atlassian.net/browse/OCPBUGS-62517) fix to release-4.22.

**Bug:** During OCP upgrades, `ClusterOperator olm` goes `Available=False` because the `operator-controller` and `catalogd` deployments each run with only 1 replica. When the single pod is replaced during a rolling update, there is a brief window where no pod is available.

**Fix:** Detect the cluster's `ControlPlaneTopology` from the Infrastructure CR at startup. For HighlyAvailable topologies (HighlyAvailable, HighlyAvailableArbiter, DualReplica), override Helm values to `replicas=2` and `podDisruptionBudget.enabled=true` before rendering manifests. SingleReplica (SNO) and External topologies keep defaults of `replicas=1` and PDB disabled.

## Changes

- `helmvalues`: add `SetIntValue` and `SetBoolValue` helpers
- `clients`: add `InfrastructureClient` backed by the config informer
- `controller/builder`: add `Infrastructure` field to `Builder`
- `controller/helm`: apply HA replica/PDB overrides in `renderHelmTemplate`; add `isHighlyAvailableTopology` helper
- `main`: fetch infra at startup, pass to Builder, watch for topology changes and exit to trigger re-render

## Test plan

- [ ] Verify CI passes for upgrade jobs
- [ ] Check `periodic-ci-openshift-release-main-ci-4.22-e2e-gcp-ovn-upgrade` passes `clusteroperator/olm should not change condition/Available` test
- [ ] On HA cluster: operator-controller and catalogd deployments have 2 replicas and a PDB with `minAvailable: 1`
- [ ] On SNO cluster: replicas=1, no PDB (non-HA behavior unchanged)

**Paired PR:** operator-framework-operator-controller release-4.22 (#758) — provides the Helm values knobs that this operator overrides

Jira: https://redhat.atlassian.net/browse/OCPBUGS-94187

🤖 Generated with [Claude Code](https://claude.com/claude-code)