### PR TITLE
OPRUN-4696: fix upgrade block message and add 5.0 cluster unit tests

### DIFF
--- a/internal/versionutils/version_utils.go
+++ b/internal/versionutils/version_utils.go
@@ -65,6 +65,17 @@ func ToAllowedSemver(data []byte) (*semver.Version, error) {
 // equivalent release. Neither upgrades to the other; both upgrade exclusively to 5.1.
 var ocpVersion500 = semver.Version{Major: 5, Minor: 0, Patch: 0}
 
+// NextOCPMinorVersion returns the next OCP minor version string after current.
+// The general rule is MAJOR.(MINOR+1), with one special case:
+// OCP 4.23 and 5.0 are co-released equivalents whose only upgrade target is 5.1,
+// so a cluster at 4.23 returns "5.1" rather than the naive "4.24".
+func NextOCPMinorVersion(current semver.Version) string {
+	if current.Major == 4 && current.Minor == 23 {
+		return "5.1"
+	}
+	return fmt.Sprintf("%d.%d", current.Major, current.Minor+1)
+}
+
 // IsOperatorMaxOCPVersionCompatibleWithCluster compares the operator's maximum openshift version with the current cluster version
 // and returns whether the operator is upgradable to the next cluster version. For example,
 //

--- a/internal/versionutils/version_utils_test.go
+++ b/internal/versionutils/version_utils_test.go
@@ -95,6 +95,40 @@ func TestToAllowedSemver(t *testing.T) {
 	}
 }
 
+func TestNextOCPMinorVersion(t *testing.T) {
+	tests := []struct {
+		name    string
+		current semver.Version
+		want    string
+	}{
+		{
+			name:    "4.22 => 4.23",
+			current: semver.Version{Major: 4, Minor: 22},
+			want:    "4.23",
+		},
+		{
+			name:    "4.23 => 5.1 (co-release special case, not 4.24)",
+			current: semver.Version{Major: 4, Minor: 23},
+			want:    "5.1",
+		},
+		{
+			name:    "5.0 => 5.1",
+			current: semver.Version{Major: 5, Minor: 0},
+			want:    "5.1",
+		},
+		{
+			name:    "5.1 => 5.2",
+			current: semver.Version{Major: 5, Minor: 1},
+			want:    "5.2",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, NextOCPMinorVersion(tt.current))
+		})
+	}
+}
+
 func TestIsOperatorMaxOCPVersionCompatibleWithCluster(t *testing.T) {
 	tests := []struct {
 		name                   string

--- a/pkg/controller/incompatible_operator_controller.go
+++ b/pkg/controller/incompatible_operator_controller.go
@@ -92,8 +92,7 @@ func (c *incompatibleOperatorController) sync(ctx context.Context, _ factory.Syn
 		// deterministic ordering
 		sort.Strings(incompatibleOperators)
 
-		// TODO(4.23): Update this message when main becomes 4.23 development
-		message := fmt.Sprintf("Found ClusterExtensions that require upgrades prior to upgrading cluster to version 4.23 or 5.0: %s.", strings.Join(incompatibleOperators, ","))
+		message := fmt.Sprintf("Found ClusterExtensions that require upgrades prior to upgrading cluster to version %s: %s.", versionutils.NextOCPMinorVersion(*c.currentOCPMinorVersion), strings.Join(incompatibleOperators, ","))
 		if err != nil {
 			message += fmt.Sprintf("\n Additionally the following errors were encountered while getting extension metadata: %s", err.Error())
 		}

--- a/pkg/controller/incompatible_operator_controller_test.go
+++ b/pkg/controller/incompatible_operator_controller_test.go
@@ -423,6 +423,133 @@ func TestIncompatibleOperatorController_Sync(t *testing.T) {
 				conditionReason: "",
 			},
 		},
+		// 5.0 cluster cases: maxOCPVersion=5.0 and maxOCPVersion=4.23 both block (next target is 5.1).
+		{
+			name: "boxcutter: maxOCPVersion=5.0 with cluster at 5.0 is not upgradable",
+			args: args{
+				clusterExtensions: []runtime.Object{
+					createClusterExtension("test-operator"),
+				},
+				clusterObjectSets: []runtime.Object{
+					createObjectSet("test-operator-rev1", 1, "Active", "test-operator", "test-bundle-1.0", olmPropertyAnnotation(`[{"type":"olm.maxOpenShiftVersion","value":"5.0"}]`)),
+				},
+				currentOCPVersion: "5.0.0",
+				boxCutterEnabled:  true,
+			},
+			wants: wants{
+				conditionStatus:   operatorv1.ConditionFalse,
+				conditionReason:   reasonIncompatibleOperatorsInstalled,
+				messageContaining: "test-bundle-1.0",
+			},
+		},
+		{
+			name: "boxcutter: maxOCPVersion=4.23 with cluster at 5.0 is not upgradable",
+			args: args{
+				clusterExtensions: []runtime.Object{
+					createClusterExtension("test-operator"),
+				},
+				clusterObjectSets: []runtime.Object{
+					createObjectSet("test-operator-rev1", 1, "Active", "test-operator", "test-bundle-1.0", olmPropertyAnnotation(`[{"type":"olm.maxOpenShiftVersion","value":"4.23"}]`)),
+				},
+				currentOCPVersion: "5.0.0",
+				boxCutterEnabled:  true,
+			},
+			wants: wants{
+				conditionStatus:   operatorv1.ConditionFalse,
+				conditionReason:   reasonIncompatibleOperatorsInstalled,
+				messageContaining: "test-bundle-1.0",
+			},
+		},
+		{
+			name: "helm: maxOCPVersion=5.0 with cluster at 5.0 is not upgradable",
+			args: args{
+				clusterExtensions: []runtime.Object{
+					createClusterExtension("test-operator"),
+				},
+				helmReleases: []runtime.Object{
+					createHelmReleaseSecret("test-operator", "test-bundle-1.0", "test-package", olmPropertyAnnotation(`[{"type":"olm.maxOpenShiftVersion","value":"5.0"}]`)),
+				},
+				currentOCPVersion: "5.0.0",
+				boxCutterEnabled:  false,
+			},
+			wants: wants{
+				conditionStatus:   operatorv1.ConditionFalse,
+				conditionReason:   reasonIncompatibleOperatorsInstalled,
+				messageContaining: "test-bundle-1.0",
+			},
+		},
+		{
+			name: "helm: maxOCPVersion=4.23 with cluster at 5.0 is not upgradable",
+			args: args{
+				clusterExtensions: []runtime.Object{
+					createClusterExtension("test-operator"),
+				},
+				helmReleases: []runtime.Object{
+					createHelmReleaseSecret("test-operator", "test-bundle-1.0", "test-package", olmPropertyAnnotation(`[{"type":"olm.maxOpenShiftVersion","value":"4.23"}]`)),
+				},
+				currentOCPVersion: "5.0.0",
+				boxCutterEnabled:  false,
+			},
+			wants: wants{
+				conditionStatus:   operatorv1.ConditionFalse,
+				conditionReason:   reasonIncompatibleOperatorsInstalled,
+				messageContaining: "test-bundle-1.0",
+			},
+		},
+		{
+			name: "incompatible message names next upgrade target: 5.0 cluster => 5.1",
+			args: args{
+				clusterExtensions: []runtime.Object{
+					createClusterExtension("test-operator"),
+				},
+				helmReleases: []runtime.Object{
+					createHelmReleaseSecret("test-operator", "test-bundle-1.0", "test-package", olmPropertyAnnotation(`[{"type":"olm.maxOpenShiftVersion","value":"5.0"}]`)),
+				},
+				currentOCPVersion: "5.0.0",
+				boxCutterEnabled:  false,
+			},
+			wants: wants{
+				conditionStatus:   operatorv1.ConditionFalse,
+				conditionReason:   reasonIncompatibleOperatorsInstalled,
+				messageContaining: "5.1",
+			},
+		},
+		{
+			name: "incompatible message names next upgrade target: 4.23 cluster => 5.1 (not 4.24)",
+			args: args{
+				clusterExtensions: []runtime.Object{
+					createClusterExtension("test-operator"),
+				},
+				helmReleases: []runtime.Object{
+					createHelmReleaseSecret("test-operator", "test-bundle-1.0", "test-package", olmPropertyAnnotation(`[{"type":"olm.maxOpenShiftVersion","value":"5.0"}]`)),
+				},
+				currentOCPVersion: "4.23.0",
+				boxCutterEnabled:  false,
+			},
+			wants: wants{
+				conditionStatus:   operatorv1.ConditionFalse,
+				conditionReason:   reasonIncompatibleOperatorsInstalled,
+				messageContaining: "5.1",
+			},
+		},
+		{
+			name: "incompatible message names next upgrade target: 5.1 cluster => 5.2",
+			args: args{
+				clusterExtensions: []runtime.Object{
+					createClusterExtension("test-operator"),
+				},
+				helmReleases: []runtime.Object{
+					createHelmReleaseSecret("test-operator", "test-bundle-1.0", "test-package", olmPropertyAnnotation(`[{"type":"olm.maxOpenShiftVersion","value":"5.1"}]`)),
+				},
+				currentOCPVersion: "5.1.0",
+				boxCutterEnabled:  false,
+			},
+			wants: wants{
+				conditionStatus:   operatorv1.ConditionFalse,
+				conditionReason:   reasonIncompatibleOperatorsInstalled,
+				messageContaining: "5.2",
+			},
+		},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
Update the incompatible operator message from "4.23 or 5.0" to "5.1": OCP 4.23 and 5.0 are co-released equivalents whose only upgrade target is 5.1, so the message should name that target.

Add missing controller-level unit tests for the 5.0 cluster side of the 4.23/5.0 boundary: maxOCPVersion=5.0 and maxOCPVersion=4.23 both block on a 5.0 cluster (next target is 5.1). Also add a test asserting the message contains "5.1" to lock in the fix.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved incompatibility messaging by dynamically determining the next upgrade target version, including correct handling for 4.23 → 5.1 and subsequent 5.0/5.1 upgrade paths.
  * Expanded detection and messaging validation for incompatible operators during 5.0 cluster upgrades, including both Boxcutter and Helm-managed operators.

* **Tests**
  * Added unit tests to verify next OCP minor version calculations and updated controller test coverage for additional 5.0-related scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->