### PR TITLE
NO-ISSUE: Remove stale reviewers/approvers, add trgeiger

### DIFF
--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -1,24 +1,21 @@
-
 aliases:
    # contributors who can approve any PRs in the repo
    operator-runtime-approvers:
    - grokspawn
    - joelanford
-   - oceanc80
    - pedjak
    - perdasilva
    - tmshort
-   - jianzhangbjz
 
    # contributors who can review/lgtm any PRs in the repo
    operator-runtime-reviewers:
-   - anik120
    - ankitathomas
    - dtfranz
    - fgiudici
    - grokspawn
    - joelanford
-   - oceanc80
    - pedjak
    - perdasilva
+   - rashmigottipati
    - tmshort
+   - trgeiger


### PR DESCRIPTION
Remove stale handles from `OWNERS_ALIASES` and add `trgeiger`.

**Removed from `operator-runtime-approvers`:** `oceanc80`, `jianzhangbjz`
**Removed from `operator-runtime-reviewers`:** `anik120`, `oceanc80`
**Added to `operator-runtime-reviewers`:** `trgeiger`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated contributor approval and review assignments for operator runtime contributions.
  * Removed selected inactive approver/reviewer entries and added new reviewer entries.
  * Updated the reviewer alias list accordingly; all other assignments remain unchanged.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->