### PR TITLE
NO-ISSUE: Add dependabot configuration

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,11 @@
+version: 2
+updates:
+  - package-ecosystem: gomod
+    directory: /
+    schedule:
+      interval: weekly
+    groups:
+      k8s-dependencies:
+        patterns:
+          - "k8s.io/*"
+          - "sigs.k8s.io/*"


### PR DESCRIPTION
## Summary

- Adds `.github/dependabot.yml` to enable Dependabot for Go module dependency updates
- Configured with weekly schedule, grouping `k8s.io/*` and `sigs.k8s.io/*` dependencies together

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added weekly automated updates for Go modules.
  * Grouped related Kubernetes dependency updates together for easier review.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->